### PR TITLE
fix21 instead of using strlen() we can use !empty()

### DIFF
--- a/src/Model/Group/Group.php
+++ b/src/Model/Group/Group.php
@@ -65,7 +65,7 @@ class Group extends APIObject
     protected function read()
     {
         $data = json_decode(xoctRequest::root()->groups($this->getIdentifier())->get());
-        if(strlen($data) > 0) {
+        if(!empty($data)) {
             $this->loadFromStdClass($data);
         }
     }


### PR DESCRIPTION
Thsi should fix this issue: 
https://github.com/opencast-ilias/OpenCast/issues/21 
mit empty() kan sowohl auf einen String als auch auf eine Klasse überprüft werden.