### PR TITLE
fix for #22: Input can be configured in plugin-config

### DIFF
--- a/classes/Conf/class.xoctConfFormGUI.php
+++ b/classes/Conf/class.xoctConfFormGUI.php
@@ -216,6 +216,10 @@ class xoctConfFormGUI extends ilPropertyFormGUI {
 		$te->setInfo($this->parent_gui->txt(PluginConfig::F_EDITOR_LINK . '_info'));
 		$this->addItem($te);
 
+		$te = new ilTextInputGUI($this->parent_gui->txt(PluginConfig::F_SCHEDULE_CHANNEL), PluginConfig::F_SCHEDULE_CHANNEL);
+		$te->setInfo($this->parent_gui->txt(PluginConfig::F_SCHEDULE_CHANNEL . '_info'));
+		$this->addItem($te);
+
 		$cb = new ilCheckboxInputGUI($this->parent_gui->txt(PluginConfig::F_CREATE_SCHEDULED_ALLOWED), PluginConfig::F_CREATE_SCHEDULED_ALLOWED);
 		$cb->setInfo($this->parent_gui->txt(PluginConfig::F_CREATE_SCHEDULED_ALLOWED . '_info'));
 		$this->addItem($cb);

--- a/classes/Conf/class.xoctConfFormGUI.php
+++ b/classes/Conf/class.xoctConfFormGUI.php
@@ -218,6 +218,7 @@ class xoctConfFormGUI extends ilPropertyFormGUI {
 
 		$te = new ilTextInputGUI($this->parent_gui->txt(PluginConfig::F_SCHEDULE_CHANNEL), PluginConfig::F_SCHEDULE_CHANNEL);
 		$te->setInfo($this->parent_gui->txt(PluginConfig::F_SCHEDULE_CHANNEL . '_info'));
+		$te->setMulti(true);
 		$this->addItem($te);
 
 		$cb = new ilCheckboxInputGUI($this->parent_gui->txt(PluginConfig::F_CREATE_SCHEDULED_ALLOWED), PluginConfig::F_CREATE_SCHEDULED_ALLOWED);

--- a/classes/Service/class.xoctEventAPI.php
+++ b/classes/Service/class.xoctEventAPI.php
@@ -101,6 +101,7 @@ class xoctEventAPI
             $location,
             $start instanceof DateTime ? DateTimeImmutable::createFromMutable($start) : new DateTimeImmutable($start),
             $end instanceof DateTime ? DateTimeImmutable::createFromMutable($end) : new DateTimeImmutable($end),
+            PluginConfig::getConfig(PluginConfig::F_SCHEDULE_CHANNEL)
         );
 
 

--- a/classes/Service/class.xoctEventAPI.php
+++ b/classes/Service/class.xoctEventAPI.php
@@ -101,7 +101,7 @@ class xoctEventAPI
             $location,
             $start instanceof DateTime ? DateTimeImmutable::createFromMutable($start) : new DateTimeImmutable($start),
             $end instanceof DateTime ? DateTimeImmutable::createFromMutable($end) : new DateTimeImmutable($end),
-            PluginConfig::getConfig(PluginConfig::F_SCHEDULE_CHANNEL)
+            PluginConfig::getConfig(PluginConfig::F_SCHEDULE_CHANNEL)[0] == "" ? ['default'] :  PluginConfig::getConfig(PluginConfig::F_SCHEDULE_CHANNEL)
         );
 
 

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -20,6 +20,8 @@ config_audio_allowed#:#Audio-Dateien
 config_cancel#:#Abbrechen
 config_create_scheduled_allowed#:#"Aufzeichnungstermin(e) planen" erlauben
 config_create_scheduled_allowed_info#:#Achtung: Das planen von Aufzeichnungsterminen ist erst ab Opencast API-Version 1.1.0 möglich.
+config_schedule_channel#:#Input-Wert für Scheduling
+config_schedule_channel_info#:#Input Wert, der an die Capture Agents geschickt wird, wenn Aufzeichnungen über das Plugin geplant werden. Hinweis: Scheduling benötigt die API v1.1.0.
 config_common_idp#:#Gemeinsamer IdP
 config_common_idp_info#:#Auswählen, falls ILIAS und Opencast den selben Identity Provider verwenden (z.B. Shibboleth oder LDAP). Dadurch können gewisse Rechteprüfungen genauer durchgeführt werden ("als User" statt nur "mit Rolle des Users").
 config_oc_studio_allowed#:#Opencast Studio aktivieren

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -20,6 +20,8 @@ config_audio_allowed#:#Audio Files
 config_cancel#:#Cancel
 config_create_scheduled_allowed#:#Activate "Schedule Event(s)"
 config_create_scheduled_allowed_info#:#Warning: Scheduling events requires Opencast API v1.1.0.
+config_schedule_channel#:#Input value for scheduling
+config_schedule_channel_info#:#Input value sent to the capture agents when scheduling events via plugin. Warning: Scheduling events requires SWITCHcast API v1.1.0.
 config_common_idp#:#Common IdP
 config_common_idp_info#:#Check if ILIAS and Opencast are using the same identity provider (e.g. Shibboleth or LDAP). This allows for more precise permission checks ("as-user" instead of "with-user-role").
 config_external_download_source#:#External download source

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -21,7 +21,7 @@ config_cancel#:#Cancel
 config_create_scheduled_allowed#:#Activate "Schedule Event(s)"
 config_create_scheduled_allowed_info#:#Warning: Scheduling events requires Opencast API v1.1.0.
 config_schedule_channel#:#Input value for scheduling
-config_schedule_channel_info#:#Input value sent to the capture agents when scheduling events via plugin. Warning: Scheduling events requires SWITCHcast API v1.1.0.
+config_schedule_channel_info#:#Input value sent to the capture agents when scheduling events via plugin. Warning: Scheduling events requires API v1.1.0.
 config_common_idp#:#Common IdP
 config_common_idp_info#:#Check if ILIAS and Opencast are using the same identity provider (e.g. Shibboleth or LDAP). This allows for more precise permission checks ("as-user" instead of "with-user-role").
 config_external_download_source#:#External download source

--- a/src/Model/Config/PluginConfig.php
+++ b/src/Model/Config/PluginConfig.php
@@ -63,6 +63,7 @@ class PluginConfig extends ActiveRecord
     const F_SIGN_THUMBNAIL_LINKS_TIME = 'sign_thumbnail_links_time';
     const F_SIGN_THUMBNAIL_LINKS_WITH_IP = 'sign_thumbnail_links_with_ip';
     const F_AUDIO_ALLOWED = 'audio_allowed';
+    const F_SCHEDULE_CHANNEL = 'schedule_channel';
     const F_CREATE_SCHEDULED_ALLOWED = 'create_scheduled_allowed';
     const F_STUDIO_ALLOWED = 'oc_studio_allowed';
     const F_EXT_DL_SOURCE = 'external_download_source';

--- a/src/Model/Scheduling/Scheduling.php
+++ b/src/Model/Scheduling/Scheduling.php
@@ -44,7 +44,7 @@ class Scheduling implements JsonSerializable
     public function __construct(string             $agent_id,
                                 DateTimeImmutable  $start,
                                 ?DateTimeImmutable $end = null,
-                                array              $inputs = ['default'],
+                                ?array             $inputs = ['default'],
                                 ?int               $duration = null,
                                 ?RRule             $rrule = null)
     {

--- a/src/Model/Scheduling/Scheduling.php
+++ b/src/Model/Scheduling/Scheduling.php
@@ -44,9 +44,9 @@ class Scheduling implements JsonSerializable
     public function __construct(string             $agent_id,
                                 DateTimeImmutable  $start,
                                 ?DateTimeImmutable $end = null,
+                                array              $inputs = ['default'],
                                 ?int               $duration = null,
-                                ?RRule             $rrule = null,
-                                array              $inputs = ['default'])
+                                ?RRule             $rrule = null)
     {
         $this->agent_id = $agent_id;
         $this->start = $start;

--- a/src/Model/Scheduling/SchedulingParser.php
+++ b/src/Model/Scheduling/SchedulingParser.php
@@ -19,6 +19,7 @@ class SchedulingParser
         $data = $form_data['scheduling'];
         $type = $data[0];
         $scheduling_data = $data[1];
+        $channel =  PluginConfig::getConfig(PluginConfig::F_SCHEDULE_CHANNEL)[0] == "" ? ['default'] :  PluginConfig::getConfig(PluginConfig::F_SCHEDULE_CHANNEL);
         switch ($type) {
             case 'repeat':
                 $start = new DateTimeImmutable($scheduling_data['start_date'] . ' ' . $scheduling_data['start_time']);
@@ -27,13 +28,13 @@ class SchedulingParser
                 return new Scheduling($form_data[MDFieldDefinition::F_LOCATION],
                     $start,
                     $end,
-                    PluginConfig::getConfig(PluginConfig::F_SCHEDULE_CHANNEL),
+                    $channel,
                     $duration,
                     RRule::fromStartAndWeekdays($start, $scheduling_data['weekdays']));
             case 'no_repeat':
                 $start = new DateTimeImmutable($scheduling_data['start_date_time']);
                 $end = new DateTimeImmutable($scheduling_data['end_date_time']);
-                return new Scheduling($form_data[MDFieldDefinition::F_LOCATION], $start, $end, PluginConfig::getConfig(PluginConfig::F_SCHEDULE_CHANNEL));
+                return new Scheduling($form_data[MDFieldDefinition::F_LOCATION], $start, $end, $channel);
         }
         throw new xoctException(xoctException::INTERNAL_ERROR, $type . ' is not a valid scheduling type');
     }
@@ -44,7 +45,8 @@ class SchedulingParser
         return new Scheduling($form_data[MDFieldDefinition::F_LOCATION],
             $form_data['start_date_time'],
             $form_data['end_date_time'],
-            PluginConfig::getConfig(PluginConfig::F_SCHEDULE_CHANNEL));
+            PluginConfig::getConfig(PluginConfig::F_SCHEDULE_CHANNEL)[0] == "" ? ['default'] :  PluginConfig::getConfig(PluginConfig::F_SCHEDULE_CHANNEL)
+        );
     }
 
     public function parseApiResponse(stdClass $data) : Scheduling

--- a/src/Model/Scheduling/SchedulingParser.php
+++ b/src/Model/Scheduling/SchedulingParser.php
@@ -7,6 +7,7 @@ use Exception;
 use srag\Plugins\Opencast\Model\Metadata\Definition\MDFieldDefinition;
 use stdClass;
 use xoctException;
+use srag\Plugins\Opencast\Model\Config\PluginConfig;
 
 class SchedulingParser
 {
@@ -26,12 +27,13 @@ class SchedulingParser
                 return new Scheduling($form_data[MDFieldDefinition::F_LOCATION],
                     $start,
                     $end,
+                    PluginConfig::getConfig(PluginConfig::F_SCHEDULE_CHANNEL),
                     $duration,
                     RRule::fromStartAndWeekdays($start, $scheduling_data['weekdays']));
             case 'no_repeat':
                 $start = new DateTimeImmutable($scheduling_data['start_date_time']);
                 $end = new DateTimeImmutable($scheduling_data['end_date_time']);
-                return new Scheduling($form_data[MDFieldDefinition::F_LOCATION], $start, $end);
+                return new Scheduling($form_data[MDFieldDefinition::F_LOCATION], $start, $end, PluginConfig::getConfig(PluginConfig::F_SCHEDULE_CHANNEL));
         }
         throw new xoctException(xoctException::INTERNAL_ERROR, $type . ' is not a valid scheduling type');
     }
@@ -41,7 +43,8 @@ class SchedulingParser
         // for some reason unknown to me, the start/end are already DateTimeImmutables here...
         return new Scheduling($form_data[MDFieldDefinition::F_LOCATION],
             $form_data['start_date_time'],
-            $form_data['end_date_time']);
+            $form_data['end_date_time'],
+            PluginConfig::getConfig(PluginConfig::F_SCHEDULE_CHANNEL));
     }
 
     public function parseApiResponse(stdClass $data) : Scheduling
@@ -50,9 +53,10 @@ class SchedulingParser
             $data->agent_id,
             new DateTimeImmutable($data->start),
             new DateTimeImmutable($data->end),
+            $data->inputs,
             null,
-            null,
-            $data->inputs
+            null
+
         );
     }
 


### PR DESCRIPTION
This should solve #22 
It makes it possible to add an Input-Channel in the config. This value is the used when scheduling over the api or when scheduling inside of an opencast-series.