### PR TITLE
Custom Studio URL

### DIFF
--- a/classes/Conf/class.xoctConfFormGUI.php
+++ b/classes/Conf/class.xoctConfFormGUI.php
@@ -228,6 +228,11 @@ class xoctConfFormGUI extends ilPropertyFormGUI {
 		$cb->setInfo($this->parent_gui->txt(PluginConfig::F_STUDIO_ALLOWED . '_info'));
 		$this->addItem($cb);
 
+		// Studio Link.
+		$te = new ilTextInputGUI($this->parent_gui->txt(PluginConfig::F_STUDIO_URL), PluginConfig::F_STUDIO_URL);
+		$te->setInfo($this->parent_gui->txt(PluginConfig::F_STUDIO_URL . '_info'));
+		$cb->addSubItem($te);
+
 		$cb = new ilCheckboxInputGUI($this->parent_gui->txt(PluginConfig::F_AUDIO_ALLOWED), PluginConfig::F_AUDIO_ALLOWED);
 		$cb->setInfo($this->parent_gui->txt(PluginConfig::F_AUDIO_ALLOWED . '_info'));
 		$this->addItem($cb);

--- a/classes/Event/class.xoctEventGUI.php
+++ b/classes/Event/class.xoctEventGUI.php
@@ -729,11 +729,18 @@ class xoctEventGUI extends xoctGUI
         $base = rtrim(PluginConfig::getConfig(PluginConfig::F_API_BASE), "/");
         $base = str_replace('/api', '', $base);
 
+        $studio_link = $base . '/studio';
+
+        // get the custom url for the studio.
+        $custom_url = PluginConfig::getConfig(PluginConfig::F_STUDIO_URL);
+        if (!empty($custom_url)) {
+            $studio_link = rtrim($custom_url, "/");
+        }
+
         $return_link = ILIAS_HTTP_PATH . '/'
             . self::dic()->ctrl()->getLinkTarget($this, self::CMD_STANDARD);
 
-        $studio_link = $base . '/studio'
-            . '?upload.seriesId=' . $this->objectSettings->getSeriesIdentifier()
+        $studio_link .= '?upload.seriesId=' . $this->objectSettings->getSeriesIdentifier()
             . '&return.label=ILIAS'
             . '&return.target=' . urlencode($return_link);
         header('Location:' . $studio_link);

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -24,6 +24,8 @@ config_common_idp#:#Gemeinsamer IdP
 config_common_idp_info#:#Auswählen, falls ILIAS und Opencast den selben Identity Provider verwenden (z.B. Shibboleth oder LDAP). Dadurch können gewisse Rechteprüfungen genauer durchgeführt werden ("als User" statt nur "mit Rolle des Users").
 config_oc_studio_allowed#:#Opencast Studio aktivieren
 config_oc_studio_allowed_info#:#Ermöglichen Sie Benutzern den Zugriff auf Opencast Studio von Ilias aus (Erfordert Opencast > 8.3)
+config_oc_studio_url#:#Opencast Studio URL
+config_oc_studio_url_info#:#Eine benutzerdefinierte URL für Opencast Studio. Default: https://[ihre-opencast-url.de]/studio
 config_curl#:#cURL
 config_curl_debug_level#:#Debug-Level
 config_curl_password#:#API-Passwort

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -26,6 +26,8 @@ config_external_download_source#:#External download source
 config_external_download_source_info#:#Enable this option in case of an external web page to show the downloads
 config_oc_studio_allowed#:#Enable Opencast Studio
 config_oc_studio_allowed_info#:#Allow users to access to Opencast Studio from Ilias (Requires Opencast > 8.3)
+config_oc_studio_url#:#Opencast Studio URL
+config_oc_studio_url_info#:#A custom URL for Opencast Studio. Default: https://[your-opencast-url.com]/studio
 config_curl#:#cURL
 config_curl_debug_level#:#Debug level
 config_curl_password#:#API password

--- a/src/Model/Config/PluginConfig.php
+++ b/src/Model/Config/PluginConfig.php
@@ -65,6 +65,7 @@ class PluginConfig extends ActiveRecord
     const F_AUDIO_ALLOWED = 'audio_allowed';
     const F_CREATE_SCHEDULED_ALLOWED = 'create_scheduled_allowed';
     const F_STUDIO_ALLOWED = 'oc_studio_allowed';
+    const F_STUDIO_URL = 'oc_studio_url';
     const F_EXT_DL_SOURCE = 'external_download_source';
     const F_VIDEO_PORTAL_LINK = 'video_portal_link';
     const F_VIDEO_PORTAL_TITLE = 'video_portal_title';


### PR DESCRIPTION
This PR fixes #7, by providing a new setting to use a custom URL for studio.

What is new:
- a new text input has been added as a sub-item to the checkbox that manages the Studio "Enable Opencast Studio" under Settings > Events.
