### PR TITLE
Optional producers group

### DIFF
--- a/classes/Conf/class.xoctConfFormGUI.php
+++ b/classes/Conf/class.xoctConfFormGUI.php
@@ -421,7 +421,6 @@ class xoctConfFormGUI extends ilPropertyFormGUI {
 		foreach (PluginConfig::$groups as $group) {
 			$te = new ilTextInputGUI($this->parent_gui->txt($group), $group);
 			$te->setInfo($this->parent_gui->txt($group . '_info'));
-			$te->setRequired(true);
 			$this->addItem($te);
 		}
 

--- a/classes/Event/class.xoctEventGUI.php
+++ b/classes/Event/class.xoctEventGUI.php
@@ -1219,11 +1219,13 @@ class xoctEventGUI extends xoctGUI
     {
         $xoctUser = xoctUser::getInstance(self::dic()->user());
         // add user to ilias producers
+        $sleep = false;
         try {
-            $ilias_producers = Group::find(PluginConfig::getConfig(PluginConfig::F_GROUP_PRODUCERS));
-            $sleep = $ilias_producers->addMember($xoctUser);
+            if ($group_producers = PluginConfig::getConfig(PluginConfig::F_GROUP_PRODUCERS)) {
+                $ilias_producers = Group::find($group_producers);
+                $sleep = $ilias_producers->addMember($xoctUser);
+            }
         } catch (xoctException $e) {
-            $sleep = false;
         }
 
         // add user to series producers

--- a/classes/Service/class.xoctSeriesAPI.php
+++ b/classes/Service/class.xoctSeriesAPI.php
@@ -157,8 +157,10 @@ class xoctSeriesAPI
         }
 
         try {
-            $ilias_producers = Group::find(PluginConfig::getConfig(PluginConfig::F_GROUP_PRODUCERS));
-            $ilias_producers->addMembers($producers);
+            if ($group_producers = PluginConfig::getConfig(PluginConfig::F_GROUP_PRODUCERS)) {
+                $ilias_producers = Group::find($group_producers);
+                $ilias_producers->addMembers($producers);
+            }
         } catch (xoctException $e) {
         }
 

--- a/classes/class.ilObjOpenCastGUI.php
+++ b/classes/class.ilObjOpenCastGUI.php
@@ -393,8 +393,10 @@ class ilObjOpenCastGUI extends ilObjectPluginGUI
         $producers[] = xoctUser::getInstance($this->ilias_dic->user());
 
         try {
-            $ilias_producers = Group::find(PluginConfig::getConfig(PluginConfig::F_GROUP_PRODUCERS));
-            $ilias_producers->addMembers($producers);
+            if ($group_producers = PluginConfig::getConfig(PluginConfig::F_GROUP_PRODUCERS)) {
+                $ilias_producers = Group::find($group_producers);
+                $ilias_producers->addMembers($producers);
+            }
         } catch (xoctException $e) {
             self::dic()->log()->warning('Could not add producers to group while creating a series, msg: '
                 . $e->getMessage());


### PR DESCRIPTION
This PR fixes #16, by making the `ILIAS Producers` config optional.

How it works:
- Removing the required property from the config GUI.
- Adding the if statement to where that config has been used, in order to prevent unwanted exceptions