### PR TITLE
Fix60

### DIFF
--- a/classes/Event/class.xoctEventRenderer.php
+++ b/classes/Event/class.xoctEventRenderer.php
@@ -449,7 +449,7 @@ class xoctEventRenderer {
 	 * @return string
 	 */
 	public function getStartHTML($format = 'd.m.Y - H:i') {
-		return $this->event->getStart()->format($format);
+		return $this->event->getStart()->setTimezone(new DateTimeZone(ilTimeZone::_getDefaultTimeZone()))->format($format);
 	}
 
     /**

--- a/src/Model/Scheduling/SchedulingParser.php
+++ b/src/Model/Scheduling/SchedulingParser.php
@@ -26,15 +26,15 @@ class SchedulingParser
                 $end = new DateTimeImmutable($scheduling_data['end_date'] . ' ' . $scheduling_data['end_time']);
                 $duration = $end->getTimestamp() - $start->getTimestamp();
                 return new Scheduling($form_data[MDFieldDefinition::F_LOCATION],
-                    $start,
-                    $end,
+                    $start->setTimezone(new DateTimeZone('GMT')),
+                    $end->setTimezone(new DateTimeZone('GMT')),
                     $channel,
                     $duration,
                     RRule::fromStartAndWeekdays($start, $scheduling_data['weekdays']));
             case 'no_repeat':
                 $start = new DateTimeImmutable($scheduling_data['start_date_time']);
                 $end = new DateTimeImmutable($scheduling_data['end_date_time']);
-                return new Scheduling($form_data[MDFieldDefinition::F_LOCATION], $start, $end, $channel);
+                return new Scheduling($form_data[MDFieldDefinition::F_LOCATION], $start->setTimezone(new DateTimeZone('GMT')), $end->setTimezone(new DateTimeZone('GMT')), $channel);
         }
         throw new xoctException(xoctException::INTERNAL_ERROR, $type . ' is not a valid scheduling type');
     }
@@ -43,8 +43,8 @@ class SchedulingParser
     {
         // for some reason unknown to me, the start/end are already DateTimeImmutables here...
         return new Scheduling($form_data[MDFieldDefinition::F_LOCATION],
-            $form_data['start_date_time'],
-            $form_data['end_date_time'],
+            $form_data['start_date_time']->setTimezone(new DateTimeZone('GMT')),
+            $form_data['end_date_time']->setTimezone(new DateTimeZone('GMT')),
             PluginConfig::getConfig(PluginConfig::F_SCHEDULE_CHANNEL)[0] == "" ? ['default'] :  PluginConfig::getConfig(PluginConfig::F_SCHEDULE_CHANNEL)
         );
     }

--- a/src/Model/Scheduling/SchedulingParser.php
+++ b/src/Model/Scheduling/SchedulingParser.php
@@ -2,6 +2,7 @@
 
 namespace srag\Plugins\Opencast\Model\Scheduling;
 
+use DateTimeZone;
 use DateTimeImmutable;
 use Exception;
 use srag\Plugins\Opencast\Model\Metadata\Definition\MDFieldDefinition;

--- a/src/UI/Scheduling/SchedulingFormItemBuilder.php
+++ b/src/UI/Scheduling/SchedulingFormItemBuilder.php
@@ -2,6 +2,8 @@
 
 namespace srag\Plugins\Opencast\UI\Scheduling;
 
+use DateTimeZone;
+use ilTimeZone;
 use ILIAS\Refinery\Custom\Constraint;
 use ILIAS\Refinery\Factory as RefineryFactory;
 use ILIAS\UI\Component\Input\Field\Input;
@@ -119,10 +121,10 @@ class SchedulingFormItemBuilder
         return [
             'start_date_time' => $this->ui_factory->input()->field()->dateTime($this->plugin->txt('event_start'))
                 ->withUseTime(true)->withRequired(true)
-                ->withValue($scheduling->getStart()->format('Y-m-d H:i:s')),
+                ->withValue($scheduling->getStart()->setTimezone(new DateTimeZone(ilTimeZone::_getDefaultTimeZone()))->format('Y-m-d H:i:s')),
             'end_date_time' => $this->ui_factory->input()->field()->dateTime($this->plugin->txt('event_end'))
                 ->withUseTime(true)->withRequired(true)
-                ->withValue($scheduling->getEnd()->format('Y-m-d H:i:s')),
+                ->withValue($scheduling->getEnd()->setTimezone(new DateTimeZone(ilTimeZone::_getDefaultTimeZone()))->format('Y-m-d H:i:s')),
         ];
     }
 


### PR DESCRIPTION
This PR fixes: #60 partial.

- convert timezone before sent to api back to GMT (UTC-0) für create and edit scheduled events
- convert display timezone in tile gui to ilias default timezone
- convert timezone in edit form for scheduled events to ilias default timezone

open to fix in future:
- update event start timezone (not while scheduled)
- timezone when upload new event (not scheduled)