### PR TITLE
By default "set permission for event" is not activated

### DIFF
--- a/src/UI/ObjectSettings/ObjectSettingsFormItemBuilder.php
+++ b/src/UI/ObjectSettings/ObjectSettingsFormItemBuilder.php
@@ -126,8 +126,7 @@ class ObjectSettingsFormItemBuilder
         ],
             $this->txt(self::F_PERMISSION_PER_CLIP),
             $this->txt(self::F_PERMISSION_PER_CLIP . '_info')
-        )
-            ->withValue(null);
+        )->withValue(null);
 
 
         $inputs[self::F_MEMBER_UPLOAD] = $field_factory->checkbox($this->txt(self::F_MEMBER_UPLOAD),

--- a/src/UI/ObjectSettings/ObjectSettingsFormItemBuilder.php
+++ b/src/UI/ObjectSettings/ObjectSettingsFormItemBuilder.php
@@ -125,7 +125,10 @@ class ObjectSettingsFormItemBuilder
                 $this->txt(self::F_PERMISSION_ALLOW_SET_OWN . '_info'))
         ],
             $this->txt(self::F_PERMISSION_PER_CLIP),
-            $this->txt(self::F_PERMISSION_PER_CLIP . '_info'));
+            $this->txt(self::F_PERMISSION_PER_CLIP . '_info')
+        )
+            ->withValue(null);
+
 
         $inputs[self::F_MEMBER_UPLOAD] = $field_factory->checkbox($this->txt(self::F_MEMBER_UPLOAD),
             $this->txt(self::F_MEMBER_UPLOAD . '_info'));


### PR DESCRIPTION
This fixes #54 
When creating a new series, the option "Set permission for event" is deactivated by default.