### PR TITLE
fix for #18: filtering events in ilias7

### DIFF
--- a/classes/class.xoct.php
+++ b/classes/class.xoct.php
@@ -29,6 +29,9 @@ class xoct
      */
     public static function getILIASVersion()
     {
+        if (self::isVersionGreaterString(ILIAS_VERSION_NUMERIC, '6.999')) {
+            return self::ILIAS_7;
+        }
         if (self::isVersionGreaterString(ILIAS_VERSION_NUMERIC, '5.4.999')) {
             return self::ILIAS_6;
         }


### PR DESCRIPTION
This will fix #18
The only reason the filter was not working is because there was no proper check for which ilias-version was installed. Now the plugin checks if ilias7 is installed and shows the filter only with ilias7.

There were a lot of changes in filtering from ilias6 to ilias7. There is an issue that is closed  and not fixed https://mantis.ilias.de/view.php?id=32134. That is why the filter does not work with ilias6.

