### PR TITLE
fix for #89 check permission

### DIFF
--- a/classes/Event/class.xoctEventTableGUI.php
+++ b/classes/Event/class.xoctEventTableGUI.php
@@ -87,6 +87,7 @@ class xoctEventTableGUI extends ilTable2GUI
         parent::__construct($a_parent_obj, $a_parent_cmd);
         $this->setRowTemplate('tpl.events.html', 'Customizing/global/plugins/Services/Repository/RepositoryObject/OpenCast');
         $this->setFormAction(self::dic()->ctrl()->getFormAction($a_parent_obj));
+        $data = array_filter($data, $this->filterPermissions());
         $this->setData($data);
         foreach ($data as $item) {
             /** @var Event $event */


### PR DESCRIPTION
This should fix #89.
I just called the function filterPermission in the Constructor of xoctEventTableGUI. The method was also used in the older Version of the plugin.