### PR TITLE
Fix80

### DIFF
--- a/src/Model/Event/EventAPIRepository.php
+++ b/src/Model/Event/EventAPIRepository.php
@@ -127,7 +127,7 @@ class EventAPIRepository implements EventRepository
             $request->parameter('sort', $sort);
         }
 
-        $request->parameter('withmetadata', true)
+        $request->parameter('withmetadata', false)
             ->parameter('withacl', true)
             ->parameter('withpublications', true)
             ->parameter('withscheduling', true)

--- a/src/Model/Event/EventParser.php
+++ b/src/Model/Event/EventParser.php
@@ -42,6 +42,8 @@ class EventParser
 
         if (isset($data->metadata)) {
             $event->setMetadata($this->MDParser->parseAPIResponseEvent($data->metadata));
+        }else {
+            $event->setMetadata($this->MDParser->getMetadataFromData($data));
         }
 
         if (isset($data->acl)) {


### PR DESCRIPTION
Fix for #80 
With the fix we do not request the metadata from the Opencast-API. We instead parse for the metadata needed in the information send from the API when checking just for the regular data of an event.