### PR TITLE
fix for 110: show scheduling when editing an Event

### DIFF
--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -211,6 +211,7 @@ event_msg_scheduling_conflict#:#Termin(e) konnte(n) nicht erstellt werden, da es
 event_msg_scheduled_in_past#:#Planungskonflikt: Aufzeichnungen können nicht in der Vergangenheit geplant werden.
 event_msg_end_before_start#:#Planungskonflikt: Der Endzeitpunkt der Aufzeichnung muss nach dem Anfangszeitpunkt liegen.
 event_multiple#:#Termin Wiederholen
+event_scheduling#:#Terminplanung
 event_multiple_start#:#Startdatum
 event_multiple_start_time#:#Startzeit
 event_multiple_end#:#Enddatum

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -211,6 +211,7 @@ event_msg_scheduled#:#Event(s) scheduled
 event_msg_scheduling_conflict#:#Event(s) could not be scheduled, due to an overlap with existing events:
 event_msg_scheduled_in_past#:#Scheduling error: The event has already ended.
 event_msg_end_before_start#:#Scheduling error: Schedule end has to be later than the start.
+event_scheduling#:#Scheduling
 event_multiple#:#Repeat Event
 event_multiple_start#:#Start Date
 event_multiple_start_time#:#Start Time

--- a/src/UI/EventFormBuilder.php
+++ b/src/UI/EventFormBuilder.php
@@ -241,9 +241,7 @@ class EventFormBuilder
     {
         $inputs = ['metadata' => $this->formItemBuilder->update_scheduled_section($metadata, $as_admin)];
         $allow_edit_scheduling = (PluginConfig::getConfig(PluginConfig::F_SCHEDULED_METADATA_EDITABLE) == PluginConfig::ALL_METADATA);
-        if ($allow_edit_scheduling) {
-            $inputs['scheduling'] = $this->schedulingFormItemBuilder->edit($scheduling);
-        }
+        $inputs['scheduling'] = $this->schedulingFormItemBuilder->edit($scheduling, $allow_edit_scheduling);
 
         return $this->ui_factory->input()->container()->form()->standard(
             $form_action,

--- a/src/UI/Scheduling/SchedulingFormItemBuilder.php
+++ b/src/UI/Scheduling/SchedulingFormItemBuilder.php
@@ -60,7 +60,7 @@ class SchedulingFormItemBuilder
                 MDFieldDefinition::F_LOCATION => $this->buildSchedulingLocationInput(),
                 'scheduling' => $this->buildSchedulingInput()
             ],
-            'Scheduling'
+            $this->plugin->txt('event_scheduling')
         )->withAdditionalTransformation($this->refinery_factory->custom()->transformation(function ($vs) {
             $vs['object'] = $this->schedulingParser->parseCreateFormData($vs);
             return $vs;
@@ -68,18 +68,19 @@ class SchedulingFormItemBuilder
             ->withAdditionalTransformation($this->buildConstraintStartBeforeEnd());
     }
 
-    public function edit(Scheduling $scheduling): Input
+    public function edit(Scheduling $scheduling, bool $edit_allowed) : Input
     {
         return $this->ui_factory->input()->field()->section(
             [
                 MDFieldDefinition::F_LOCATION => $this->buildSchedulingLocationInput($scheduling->getAgentId()),
             ] + $this->buildEditSchedulingInputs($scheduling),
-            'Scheduling'
+            $this->plugin->txt('event_scheduling')
         )->withAdditionalTransformation($this->refinery_factory->custom()->transformation(function ($vs) {
             $vs['object'] = $this->schedulingParser->parseUpdateFormData($vs);
             return $vs;
         }))->withAdditionalTransformation($this->buildConstraintStartAfterNow())
-            ->withAdditionalTransformation($this->buildConstraintStartBeforeEnd());
+           ->withAdditionalTransformation($this->buildConstraintStartBeforeEnd())
+           ->withDisabled(!$edit_allowed);
     }
 
     private function buildSchedulingInput(): Input


### PR DESCRIPTION
With this fix the scheduling will be shown, when editing metadata. Depending on what checkbox is chosen in th ePlugin-Configuration for "Metadata of scheduled events editable" the time and place is editable or not. 
I also changed the title for the section