### PR TITLE
[FIX] smaller chunked upload size for slow connections

### DIFF
--- a/src/UI/Form/ChunkedFile.php
+++ b/src/UI/Form/ChunkedFile.php
@@ -68,7 +68,7 @@ class ChunkedFile extends File
             },
             function ($txt, $value) {
                 return $txt("msg_no_files_selected");
-            },
+            }
         );
     }
 }

--- a/src/UI/Form/ChunkedFileRenderer.php
+++ b/src/UI/Form/ChunkedFileRenderer.php
@@ -71,7 +71,7 @@ class ChunkedFileRenderer extends Renderer
 
         $upload_limit = \ilUtil::getUploadSizeLimitBytes();
         $settings->chunked_upload = $handler->supportsChunkedUploads();
-        $settings->chunk_size = round($upload_limit / 2) * self::MIB_F;
+        $settings->chunk_size = min($upload_limit / 2, 20 * self::MB_IN_B); // we use 20MB as default chunk size which seems to be a good compromise for slow connections
         if (!$settings->chunked_upload) {
             $max_file_size = $component->getMaxFileFize() === -1
                 ? $upload_limit

--- a/templates/default/chunked_file.js
+++ b/templates/default/chunked_file.js
@@ -80,7 +80,7 @@ il.UI.Input = il.UI.Input || {};
           }
           if (progressBarElement && progressBarElement) {
             progressElement.style.display = "block";
-            if (number > this.progress_storage) {
+            if (number >= this.progress_storage) {
               progressBarElement.textContent = number + "%";
               progressBarElement.style.width = number + "%";
             }


### PR DESCRIPTION
This is concerning #88:
Defining the right chunk size is difficult. A larger chunk size leads to faster uploads, but in the case of slow connections, the upload is aborted because, for example, the connection time is exceeded. Therefore, we would probably have to change to a very small chunk size if very slow connections are also to be supported.
Suggestion here:
- Half upload limit or
- 2MB
what is smaller will be used...
