### PR TITLE
Implemented License as Metadatum

### DIFF
--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -540,6 +540,8 @@ md_visible_for_permissions#:#Sichbar für
 md_required#:#Verpflichtend
 md_read_only#:#Nicht editierbar
 md_prefill#:#Vorausgefüllt mit
+md_values#:#Mögliche Werte
+md_values_info#:#Ein Eintrag pro Zeile in der Form "Wert%sBeschreibung"
 md_prefill_none#:#Leer
 md_prefill_username_creator#:#Benutzername
 md_prefill_crs_title#:#Kurstitel

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -542,6 +542,8 @@ md_visible_for_permissions#:#Visible for
 md_required#:#Required
 md_read_only#:#Read-Only
 md_prefill#:#Prefilled with
+md_values#:#Possible values
+md_values_info#:#One Entry per line in the format "value%slabel".
 md_prefill_none#:#None
 md_prefill_username_creator#:#Username
 md_prefill_crs_title#:#Course Title

--- a/plugin.php
+++ b/plugin.php
@@ -1,6 +1,7 @@
 <?php
+
 $id = 'xoct';
-$version = '5.0.1';
+$version = '5.0.2';
 $version_check = '44ac530093a998b525b0a73ba536e64f03bbaff47446cf99e1a31d6a042a4549';
 $ilias_min_version = '6.0';
 $ilias_max_version = '7.999';

--- a/sql/dbupdate.php
+++ b/sql/dbupdate.php
@@ -436,7 +436,8 @@ $ilDB->insert('xoct_config', [
     'name' => ['text', 'version_check'],
     'value' => ['text', '44ac530093a998b525b0a73ba536e64f03bbaff47446cf99e1a31d6a042a4549']
 ]);
-$ilDB->update('il_plugin',
+$ilDB->update(
+    'il_plugin',
     ['last_update_version' => ['text', '4.0.2-oc']],
     ['plugin_id' => ['text', 'xoct']]
 );
@@ -444,4 +445,23 @@ $ilDB->update('il_plugin',
 <#38>
 <?php
 srag\Plugins\Opencast\Model\PermissionTemplate\PermissionTemplate::updateDB();
+?>
+<#39>
+<?php
+/** @var $ilDB ilDBInterface */
+
+$field_infos = [
+    'type' => 'clob',
+    'notnull' => false,
+    'default' => null
+];
+
+if (!$ilDB->tableColumnExists('xoct_md_field_event', 'values')) {
+    $ilDB->addTableColumn('xoct_md_field_event', 'values', $field_infos);
+}
+
+if (!$ilDB->tableColumnExists('xoct_md_field_series', 'values')) {
+    $ilDB->addTableColumn('xoct_md_field_series', 'values', $field_infos);
+}
+
 ?>

--- a/src/Model/Metadata/Config/Series/MDFieldConfigSeriesRepository.php
+++ b/src/Model/Metadata/Config/Series/MDFieldConfigSeriesRepository.php
@@ -73,7 +73,8 @@ class MDFieldConfigSeriesRepository implements MDFieldConfigRepository
     public function storeFromArray(array $data): MDFieldConfigAR
     {
         $ar = MDFieldConfigSeriesAR::where(['field_id' => $data['field_id']])->first();
-        if (is_null($ar)) {
+        $is_new = $ar === null;
+        if ($is_new) {
             $ar = new MDFieldConfigSeriesAR();
             $ar->setSort($this->getNextSort());
         }
@@ -84,7 +85,12 @@ class MDFieldConfigSeriesRepository implements MDFieldConfigRepository
         $ar->setPrefill(new MDPrefillOption($data['prefill']));
         $ar->setReadOnly($data['read_only']);
         $ar->setRequired($data['required']);
-        $ar->create();
+        $ar->setValuesFromEditableString($data['values'] ?? '');
+        if ($is_new) {
+            $ar->create();
+        } else {
+            $ar->update();
+        }
         return $ar;
     }
 

--- a/src/Model/Metadata/Definition/MDCatalogueFactory.php
+++ b/src/Model/Metadata/Definition/MDCatalogueFactory.php
@@ -4,38 +4,42 @@ namespace srag\Plugins\Opencast\Model\Metadata\Definition;
 
 class MDCatalogueFactory
 {
+    /**
+     * @var MDCatalogue
+     */
+    private $event_catalogue;
+    /**
+     * @var MDCatalogue
+     */
+    private $series_catalogue;
+
+    final public function __construct()
+    {
+    }
+
     public function event(): MDCatalogue
     {
-        static $catalogue;
-        if (!$catalogue) {
-            $catalogue = new MDCatalogue([
-                new MDFieldDefinition(MDFieldDefinition::F_TITLE, MDDataType::text(), false, true),
-                new MDFieldDefinition(MDFieldDefinition::F_SUBJECTS, MDDataType::text_array(), false, false),
-                new MDFieldDefinition(MDFieldDefinition::F_DESCRIPTION, MDDataType::text_long(), false, false),
-                new MDFieldDefinition(MDFieldDefinition::F_RIGHTS_HOLDER, MDDataType::text(), false, false),
-                new MDFieldDefinition(MDFieldDefinition::F_IS_PART_OF, MDDataType::text(), true, false),
-                new MDFieldDefinition(MDFieldDefinition::F_CREATOR, MDDataType::text_array(), false, false),
-                new MDFieldDefinition(MDFieldDefinition::F_START_DATE, MDDataType::datetime(), false, false),
-                new MDFieldDefinition(MDFieldDefinition::F_DURATION, MDDataType::time(), false, false),
-                new MDFieldDefinition(MDFieldDefinition::F_LOCATION, MDDataType::text(), false, false),
-                new MDFieldDefinition(MDFieldDefinition::F_SOURCE, MDDataType::text(), false, false),
-                new MDFieldDefinition(MDFieldDefinition::F_CREATED, MDDataType::datetime(), true, false),
-                new MDFieldDefinition(MDFieldDefinition::F_PUBLISHER, MDDataType::text(), false, false),
-                new MDFieldDefinition(MDFieldDefinition::F_IDENTIFIER, MDDataType::text(), true, false),
-                new MDFieldDefinition(MDFieldDefinition::F_CONTRIBUTOR, MDDataType::text_array(), false, false),
-                // language and license are selection fields in opencast, which is not implemented yet
-//                new MDFieldDefinition(MDFieldDefinition::F_LANGUAGE, MDDataType::text(), false, false),
-//                new MDFieldDefinition(MDFieldDefinition::F_LICENSE, MDDataType::text(), false, false),
-            ]);
-        }
-        return $catalogue;
+        return $this->event_catalogue ?? $this->event_catalogue = new MDCatalogue([
+            new MDFieldDefinition(MDFieldDefinition::F_TITLE, MDDataType::text(), false, true),
+            new MDFieldDefinition(MDFieldDefinition::F_SUBJECTS, MDDataType::text_array(), false, false),
+            new MDFieldDefinition(MDFieldDefinition::F_DESCRIPTION, MDDataType::text_long(), false, false),
+            new MDFieldDefinition(MDFieldDefinition::F_RIGHTS_HOLDER, MDDataType::text(), false, false),
+            new MDFieldDefinition(MDFieldDefinition::F_IS_PART_OF, MDDataType::text(), true, false),
+            new MDFieldDefinition(MDFieldDefinition::F_CREATOR, MDDataType::text_array(), false, false),
+            new MDFieldDefinition(MDFieldDefinition::F_START_DATE, MDDataType::datetime(), false, false),
+            new MDFieldDefinition(MDFieldDefinition::F_DURATION, MDDataType::time(), false, false),
+            new MDFieldDefinition(MDFieldDefinition::F_LOCATION, MDDataType::text(), false, false),
+            new MDFieldDefinition(MDFieldDefinition::F_SOURCE, MDDataType::text(), false, false),
+            new MDFieldDefinition(MDFieldDefinition::F_CREATED, MDDataType::datetime(), true, false),
+            new MDFieldDefinition(MDFieldDefinition::F_PUBLISHER, MDDataType::text(), false, false),
+            new MDFieldDefinition(MDFieldDefinition::F_IDENTIFIER, MDDataType::text(), true, false),
+            new MDFieldDefinition(MDFieldDefinition::F_CONTRIBUTOR, MDDataType::text_array(), false, false),
+        ]);
     }
 
     public function series(): MDCatalogue
     {
-        static $catalogue;
-        if (!$catalogue) {
-            return new MDCatalogue([
+        return $this->series_catalogue ?? $this->series_catalogue =  new MDCatalogue([
                 new MDFieldDefinition(MDFieldDefinition::F_TITLE, MDDataType::text(), false, true),
                 new MDFieldDefinition(MDFieldDefinition::F_DESCRIPTION, MDDataType::text_long(), false, false),
                 new MDFieldDefinition(MDFieldDefinition::F_RIGHTS_HOLDER, MDDataType::text(), false, false),
@@ -44,12 +48,7 @@ class MDCatalogueFactory
                 new MDFieldDefinition(MDFieldDefinition::F_CONTRIBUTOR, MDDataType::text_array(), false, false),
                 new MDFieldDefinition(MDFieldDefinition::F_PUBLISHER, MDDataType::text_array(), true, false),
                 new MDFieldDefinition(MDFieldDefinition::F_IDENTIFIER, MDDataType::text(), true, false),
-//                new MDFieldDefinition(MDFieldDefinition::F_SUBJECTS, MDDataType::text_array(), false, false), // subjects don't work currently (opencast bug)
-                // language and license are selection fields in opencast, which is not implemented yet
-//                new MDFieldDefinition(MDFieldDefinition::F_LICENSE, MDDataType::text(), false, false),
-//                new MDFieldDefinition(MDFieldDefinition::F_LANGUAGE, MDDataType::text(), false, false),
+                new MDFieldDefinition(MDFieldDefinition::F_LICENSE, MDDataType::text_selection(), false, false),
             ]);
-        }
-        return $catalogue;
     }
 }

--- a/src/Model/Metadata/Definition/MDDataType.php
+++ b/src/Model/Metadata/Definition/MDDataType.php
@@ -12,6 +12,7 @@ class MDDataType
     public const TYPE_DATETIME = 'datetime';
     public const TYPE_DATE = 'date';
     public const TYPE_TEXT_ARRAY = 'text_array';
+    public const TYPE_TEXT_SELECTION = 'text_selection';
     public const TYPE_TIME = 'time';
     private static $types = [
         self::TYPE_TEXT,
@@ -19,7 +20,8 @@ class MDDataType
         self::TYPE_TEXT_ARRAY,
         self::TYPE_DATETIME,
         self::TYPE_DATE,
-        self::TYPE_TIME
+        self::TYPE_TIME,
+        self::TYPE_TEXT_SELECTION,
     ];
 
     /**
@@ -50,6 +52,11 @@ class MDDataType
     public static function text_array(): self
     {
         return new self(self::TYPE_TEXT_ARRAY);
+    }
+
+    public static function text_selection(): self
+    {
+        return new self(self::TYPE_TEXT_SELECTION);
     }
 
     public static function text_long(): self
@@ -86,6 +93,7 @@ class MDDataType
     public function isValidValue($value): bool
     {
         switch ($this->getTitle()) {
+            case self::TYPE_TEXT_SELECTION:
             case self::TYPE_TEXT:
             case self::TYPE_TEXT_LONG:
                 return is_string($value);
@@ -100,7 +108,7 @@ class MDDataType
             default:
                 throw new xoctException(
                     xoctException::INTERNAL_ERROR,
-                    "invalid MDDataType: " . get_class($value)
+                    "invalid MDDataType for " . $this->getTitle()
                 );
         }
     }

--- a/src/Model/Metadata/MetadataField.php
+++ b/src/Model/Metadata/MetadataField.php
@@ -78,6 +78,7 @@ class MetadataField implements JsonSerializable
             case MDDataType::TYPE_TEXT_LONG:
             case MDDataType::TYPE_TEXT_ARRAY:
             case MDDataType::TYPE_TIME:
+            case MDDataType::TYPE_TEXT_SELECTION:
             return $this->getValue();
             case MDDataType::TYPE_DATETIME:
                 /** @var DateTimeImmutable|null $value */
@@ -96,6 +97,7 @@ class MetadataField implements JsonSerializable
             case MDDataType::TYPE_TEXT:
             case MDDataType::TYPE_TIME:
             case MDDataType::TYPE_TEXT_LONG:
+            case MDDataType::TYPE_TEXT_SELECTION:
                 return $this->getValue();
             case MDDataType::TYPE_TEXT_ARRAY:
                 return implode(', ', $this->getValue());

--- a/src/UI/Metadata/MDFormItemBuilder.php
+++ b/src/UI/Metadata/MDFormItemBuilder.php
@@ -214,11 +214,11 @@ class MDFormItemBuilder
         $field = $field
             ->withRequired($fieldConfigAR->isRequired())
             ->withDisabled($fieldConfigAR->isReadOnly());
-        return $value ? $field->withValue($this->formatValue($value, $md_definition)) : $field;
+        return $value ? $field->withValue($this->formatValue($value, $md_definition, $fieldConfigAR)) : $field;
     }
 
 
-    private function formatValue($value, MDFieldDefinition $md_definition)
+    private function formatValue($value, MDFieldDefinition $md_definition, MDFieldConfigAR $fieldConfigAR)
     {
         switch ($md_definition->getType()->getTitle()) {
             case MDDataType::TYPE_DATETIME:
@@ -227,6 +227,9 @@ class MDFormItemBuilder
             case MDDataType::TYPE_TEXT_ARRAY:
                 return is_array($value) ? implode(',', $value) : $value;
             case MDDataType::TYPE_TEXT_SELECTION:
+                if (!in_array($value, array_keys($fieldConfigAR->getValues()))) {
+                    return null;
+                }
                 return $value;
             default:
                 return $value;

--- a/src/UI/Metadata/MDFormItemBuilder.php
+++ b/src/UI/Metadata/MDFormItemBuilder.php
@@ -74,8 +74,7 @@ class MDFormItemBuilder
         MDParser $MDParser,
         ilPlugin $plugin,
         Container $dic
-    )
-    {
+    ) {
         $this->ui_factory = $ui_factory;
         $this->md_catalogue = $md_catalogue;
         $this->prefiller = $prefiller;
@@ -114,9 +113,11 @@ class MDFormItemBuilder
     public function update_section(Metadata $existing_metadata, bool $as_admin): Input
     {
         $form_elements = [];
-        $MDFieldConfigARS = $this->md_conf_repository->getAll($as_admin);
-        array_walk($MDFieldConfigARS, function (MDFieldConfigAR $md_field_config) use (&$form_elements, $existing_metadata) {
+        $stored_field_configurations = $this->md_conf_repository->getAll($as_admin);
+
+        array_walk($stored_field_configurations, function (MDFieldConfigAR $md_field_config) use (&$form_elements, $existing_metadata) {
             $key = $this->prefixPostVar($md_field_config->getFieldId());
+
             $form_elements[$key] = $this->buildFormElementForMDField(
                 $md_field_config,
                 $existing_metadata->getField($md_field_config->getFieldId())->getValue()
@@ -182,7 +183,14 @@ class MDFormItemBuilder
                 $field = $this->ui_factory->input()->field()->text($fieldConfigAR->getTitle($this->dic->language()->getLangKey()))
                     ->withAdditionalTransformation($this->refinery_factory->custom()->transformation(function (string $value) {
                         return explode(',', $value);
-                    }))->withValue(''); // can be removed if this is fixed: https://mantis.ilias.de/view.php?id=32104
+                    }));
+                break;
+            case MDDataType::TYPE_TEXT_SELECTION:
+                $field = $this->ui_factory->input()->field()->select(
+                    $fieldConfigAR->getTitle($this->dic->language()->getLangKey()),
+                    $fieldConfigAR->getValues()
+                )->withValue(null);
+
                 break;
             case MDDataType::TYPE_TEXT_LONG:
                 $field = $this->ui_factory->input()->field()->textarea($fieldConfigAR->getTitle($this->dic->language()->getLangKey()));
@@ -218,6 +226,8 @@ class MDFormItemBuilder
                 return $value instanceof DateTimeImmutable ? $value->setTimezone(new DateTimeZone(ilTimeZone::_getDefaultTimeZone()))->format('Y-m-d H:i:s') : $value;
             case MDDataType::TYPE_TEXT_ARRAY:
                 return is_array($value) ? implode(',', $value) : $value;
+            case MDDataType::TYPE_TEXT_SELECTION:
+                return $value;
             default:
                 return $value;
         }


### PR DESCRIPTION
Hi @okaufman 

To test this version, you need to come from version 5.0.1 and DB Version 38. I had to switch off DB-Cache in my settings to get it to work.

With this changes you can configure Licenses as a Metadatum for Series:

![image](https://user-images.githubusercontent.com/6661332/211329861-02144485-bb0d-4e59-8bbc-8f5f3d4d43e2.png)

one must configure the possible values to Match the values of opencast itself (e.g. 

```
ALLRIGHTS|||Alle Rechte vorbehalten
CC-BY|||CC BY
```