### PR TITLE
fix for 60: when adding events over the internal api

### DIFF
--- a/classes/Service/class.xoctEventAPI.php
+++ b/classes/Service/class.xoctEventAPI.php
@@ -101,8 +101,8 @@ class xoctEventAPI
 
         $scheduling = new Scheduling(
             $location,
-            $start instanceof DateTime ? DateTimeImmutable::createFromMutable($start) : new DateTimeImmutable($start),
-            $end instanceof DateTime ? DateTimeImmutable::createFromMutable($end) : new DateTimeImmutable($end),
+            $start instanceof DateTime ? DateTimeImmutable::createFromMutable($start->setTimezone(new DateTimeZone('GMT'))) : new DateTimeImmutable($start),
+            $end instanceof DateTime ? DateTimeImmutable::createFromMutable($end->setTimezone(new DateTimeZone('GMT'))) : new DateTimeImmutable($end),
             PluginConfig::getConfig(PluginConfig::F_SCHEDULE_CHANNEL)[0] == "" ? ['default'] : PluginConfig::getConfig(PluginConfig::F_SCHEDULE_CHANNEL)
         );
 


### PR DESCRIPTION
This should fix the problem mentioned by @samuelinniger in #60 
I just added the correct timezone as was already done so in #64 