### PR TITLE
fixes #141

### DIFF
--- a/src/UI/EventFormBuilder.php
+++ b/src/UI/EventFormBuilder.php
@@ -21,6 +21,9 @@ use srag\Plugins\Opencast\UI\Metadata\MDFormItemBuilder;
 use srag\Plugins\Opencast\UI\Scheduling\SchedulingFormItemBuilder;
 use srag\Plugins\Opencast\Util\FileTransfer\UploadStorageService;
 use ILIAS\UI\Implementation\Component\Input\Field\ChunkedFile;
+use srag\Plugins\Opencast\Model\Metadata\MetadataField;
+use srag\Plugins\Opencast\Model\Metadata\Definition\MDDataType;
+use DateTimeZone;
 
 /**
  * Responsible for creating forms to upload, schedule or edit an event.
@@ -246,7 +249,16 @@ class EventFormBuilder
         return $this->ui_factory->input()->container()->form()->standard(
             $form_action,
             $inputs
-        );
+        )->withAdditionalTransformation($this->refinery_factory->custom()->constraint(function ($vs) {
+            $date_field = new MetadataField(MDFieldDefinition::F_START_DATE, MDDataType::datetime());
+            $date_field->setValue($vs['scheduling'] ["start_date_time"]);
+            $vs['metadata']['object']->addField($date_field);
+
+            $time_field = new MetadataField(MDFieldDefinition::F_START_TIME, MDDataType::time());
+            $time_field->setValue($vs['scheduling'] ["start_date_time"]->setTimeZone(new DateTimeZone('utc'))->format('H:i:s'));
+            $vs['metadata']['object']->addField($time_field);
+            return $vs;
+        }, \xoctException::INTERNAL_ERROR));
     }
 
     private function buildTermsOfUseSection(): Input


### PR DESCRIPTION
copies the value from 'scheduling' into 'metadata'.
I needed to add two metadata-fields since opencast expects a field for the date and a field for the time (https://github.com/opencast/opencast/issues/3077) 