### PR TITLE
Fix for #143

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [4.0.1]
 - Update Paella to version 6.5.6.
+- Improvement: change default order of events in series to start date.
+
 ## [4.0.0]
 - Feature: Completely configurable metadata fields for events and series, used in forms and tables. See Configuration Tab "Metadata".
 - Feature: Accept Terms of Use once per User, when creating an Event. See Configuration at "General" -> "Series".

--- a/classes/Event/class.xoctEventTableGUI.php
+++ b/classes/Event/class.xoctEventTableGUI.php
@@ -98,7 +98,8 @@ class xoctEventTableGUI extends ilTable2GUI
             }
         }
         $this->initColumns();
-        $this->setDefaultOrderField('created_s');
+
+        $this->setDefaultOrderField('startDate_s');
 
         if (ilObjOpenCastAccess::checkAction(ilObjOpenCastAccess::ACTION_EXPORT_CSV)) {
             $this->setExportFormats([self::EXPORT_CSV]);

--- a/classes/Event/class.xoctEventTableGUI.php
+++ b/classes/Event/class.xoctEventTableGUI.php
@@ -98,7 +98,6 @@ class xoctEventTableGUI extends ilTable2GUI
             }
         }
         $this->initColumns();
-
         $this->setDefaultOrderField('startDate_s');
 
         if (ilObjOpenCastAccess::checkAction(ilObjOpenCastAccess::ACTION_EXPORT_CSV)) {

--- a/classes/Event/class.xoctEventTileGUI.php
+++ b/classes/Event/class.xoctEventTileGUI.php
@@ -68,7 +68,7 @@ class xoctEventTileGUI
         $this->limit = UserSettingsRepository::getTileLimitForUser(self::dic()->user()->getId(), filter_input(INPUT_GET, 'ref_id'));
         $this->events = array_values(array_map(function ($item) {
             return $item['object'];
-        }, $data));
+        }, $this->sortData($data)));
     }
 
     /**


### PR DESCRIPTION
Fix for #143
This will make sure that new series will use the start date as the default order in tile- or list-view. 
Series that have already been created and looked at by the user will continue to use the create date as the order. 
If you would like to change also the order of already present series, you would have to adjust the table 'table-properties' in the database.
I will use the following query to change the order:
UPDATE table_properties
SET value = 'startDate_s'
WHERE value='created_s' and table_id like 'tbl_xoct_%'; 