### PR TITLE
fix livestream overload issue

### DIFF
--- a/src/Util/check_hls_status.php
+++ b/src/Util/check_hls_status.php
@@ -13,7 +13,7 @@ function fetch(string $url): array
     curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
     curl_setopt($ch, CURLOPT_HEADER, true);
     curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
-    curl_setopt($ch, CURLOPT_TIMEOUT, 2);
+    curl_setopt($ch, CURLOPT_TIMEOUT, 5);
 
     $response = curl_exec($ch);
     $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);

--- a/src/Util/check_hls_status.php
+++ b/src/Util/check_hls_status.php
@@ -13,7 +13,7 @@ function fetch(string $url): array
     curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
     curl_setopt($ch, CURLOPT_HEADER, true);
     curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
-    curl_setopt($ch,CURLOPT_TIMEOUT,2);
+    curl_setopt($ch, CURLOPT_TIMEOUT,2);
 
     $response = curl_exec($ch);
     $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);

--- a/src/Util/check_hls_status.php
+++ b/src/Util/check_hls_status.php
@@ -13,6 +13,7 @@ function fetch(string $url): array
     curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
     curl_setopt($ch, CURLOPT_HEADER, true);
     curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
+    curl_setopt($ch,CURLOPT_TIMEOUT,2);
 
     $response = curl_exec($ch);
     $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);

--- a/src/Util/check_hls_status.php
+++ b/src/Util/check_hls_status.php
@@ -13,7 +13,7 @@ function fetch(string $url): array
     curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
     curl_setopt($ch, CURLOPT_HEADER, true);
     curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
-    curl_setopt($ch, CURLOPT_TIMEOUT,2);
+    curl_setopt($ch, CURLOPT_TIMEOUT, 2);
 
     $response = curl_exec($ch);
     $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);


### PR DESCRIPTION
This PR would fix a livestream issue that occurse when livestreams are not working.

Sometimes when the livestreams are not properly working, ilias will be slow or even unresponsive. When a lot of students are trying to access a livestream that is not working, they start many php-fpm-threads using check_hls_status.php script. (All this does is check whether the livestream is running.)
These threads will wait for an answer from the opencast-livestream. They don't receive an answer and block the thread from doing any other work.

To mitigate this issue, I would like to add a timeout of 2 seconds for the curl command in that script. So even when the livestreams are not working, the php-threads would only be blocked for 2 seconds. This would require that the opencast-server can normally give a response to ilias within 2 seconds.