### PR TITLE
Add default values to Paella options in formbuilder

### DIFF
--- a/src/UI/PaellaConfig/PaellaConfigFormBuilder.php
+++ b/src/UI/PaellaConfig/PaellaConfigFormBuilder.php
@@ -59,12 +59,12 @@ class PaellaConfigFormBuilder
     {
         $inputs[self::F_PAELLA_PLAYER_OPTION] = $this->getPaellaPlayerPathInput(
             false,
-            PluginConfig::getConfig(PluginConfig::F_PAELLA_OPTION),
+            PluginConfig::getConfig(PluginConfig::F_PAELLA_OPTION) ?? 'default',
             PluginConfig::getConfig(PluginConfig::F_PAELLA_URL) ?? ''
         );
         $inputs[self::F_PAELLA_PLAYER_LIVE_OPTION] = $this->getPaellaPlayerPathInput(
             true,
-            PluginConfig::getConfig(PluginConfig::F_PAELLA_OPTION_LIVE),
+            PluginConfig::getConfig(PluginConfig::F_PAELLA_OPTION_LIVE) ?? 'default',
             PluginConfig::getConfig(PluginConfig::F_PAELLA_URL_LIVE) ?? ''
         );
         return $this->ui_factory->input()->container()->form()->standard(


### PR DESCRIPTION
This PR fixes #177 

### Description
Please refer to the issue

### How it works
It ensures that by fresh installs the 'default' values for paella options to create the admin settings forms are correctly passed.

### How to test
- Need a fresh installation of the plugin (v5.1.1)
- ILIAS 7 (release_7) branch