### PR TITLE
Default configs never applied that leads to version check error

### DIFF
--- a/classes/class.ilOpenCastPlugin.php
+++ b/classes/class.ilOpenCastPlugin.php
@@ -45,6 +45,8 @@ class ilOpenCastPlugin extends ilRepositoryObjectPlugin
      */
     protected $db;
 
+    private $is_new_installation = false;
+
 
     /**
      *
@@ -61,6 +63,7 @@ class ilOpenCastPlugin extends ilRepositoryObjectPlugin
     {
         // Check Version
         $check = new UpdateCheck($this->db);
+        $this->is_new_installation = $check->isNewInstallation();
         if (!$check->isUpdatePossible()) {
             throw new ilPluginException(
                 'You try to update from a incompatible version of the plugin, please read the infos here: https://github.com/opencast-ilias/OpenCast/blob/main/doc/migration.md'
@@ -71,7 +74,7 @@ class ilOpenCastPlugin extends ilRepositoryObjectPlugin
 
     protected function afterUpdate()
     {
-        if (PluginConfig::count() == 0) {
+        if ($this->is_new_installation) {
             PluginConfig::importFromXML($this->getDirectory() . '/configuration/default_config.xml');
         }
     }

--- a/src/Util/UpdateCheck.php
+++ b/src/Util/UpdateCheck.php
@@ -55,4 +55,9 @@ class UpdateCheck
 
         return $this->version_check_string === $this->version_check_string_db;
     }
+
+    public function isNewInstallation(): bool
+    {
+        return $this->last_update_version === '0.0.0';
+    }
 }


### PR DESCRIPTION
This PR fixes #169
This also fixes #177
This PR also completes the PR #178

This also fixes unseen problems that might related to not defining default configs on new installations!

### Description
the problem raises when you install a new version (> 4.0.2) and want to update to a newer version of the plugin (after introducing version check). Please refer to issue #169 

### Problem
- the `version_check` is added to the `xoct_config` table during update in `dbupdate`.
- `afterUpdate` then checks if there is no config (in fact there is one, which is `version_check`), and does not apply default configs.

### How it works
- To identify that an installation is new, we now use a more precise mechanism, which is recognizing is in `UpdateCheck` class.
- In case the installation is new `last_update_version` is '0.0.0', therefore the newly added method `isNewInstallation` in `UpdateCheck` class return true, otherwise false.
- Now that we know this, we can safely check it in `afterUpdate`.

### How to test
refer to to issue #169

# IMPORTANT
For those who would run into this version check error, the solution is to make sure this patch is applied and run the following SQL command against their DB:
`UPDATE xoct_config SET value = '44ac530093a998b525b0a73ba536e64f03bbaff47446cf99e1a31d6a042a4549' WHERE xoct_config.name = 'version_check';`