### PR TITLE
Add an extra option to sign mp4 file during signing of the player link

### DIFF
--- a/classes/Conf/class.xoctConfFormGUI.php
+++ b/classes/Conf/class.xoctConfFormGUI.php
@@ -505,6 +505,9 @@ class xoctConfFormGUI extends ilPropertyFormGUI
         $cb_sub = new ilCheckboxInputGUI($this->parent_gui->txt(PluginConfig::F_SIGN_PLAYER_LINKS_WITH_IP), PluginConfig::F_SIGN_PLAYER_LINKS_WITH_IP);
         $cb->addSubItem($cb_sub);
 
+        $cb_sub = new ilCheckboxInputGUI($this->parent_gui->txt(PluginConfig::F_SIGN_PLAYER_LINKS_MP4), PluginConfig::F_SIGN_PLAYER_LINKS_MP4);
+        $cb->addSubItem($cb_sub);
+
         $cb = new ilCheckboxInputGUI($this->parent_gui->txt(PluginConfig::F_SIGN_DOWNLOAD_LINKS), PluginConfig::F_SIGN_DOWNLOAD_LINKS);
         $cb->setInfo($this->parent_gui->txt(PluginConfig::F_SIGN_DOWNLOAD_LINKS . '_info'));
         $this->addItem($cb);

--- a/classes/class.xoctSecureLink.php
+++ b/classes/class.xoctSecureLink.php
@@ -44,6 +44,8 @@ class xoctSecureLink
         $data = json_decode(xoctRequest::root()->security()->sign($url, $valid_until, $ip));
 
         if ($data->error) {
+            // We would only be able to log it here as error to avoid further confilicts.
+            xoctLog::getInstance()->write("[Error]: Signing link ($url) failed: {$data->error}", xoctLog::DEBUG_LEVEL_1);
             return '';
         }
         self::$cache[$url] = $data->url;
@@ -95,6 +97,11 @@ class xoctSecureLink
             $duration_in_seconds = $duration / 1000;
             $additional_time_percent = PluginConfig::getConfig(PluginConfig::F_SIGN_PLAYER_LINKS_ADDITIONAL_TIME_PERCENT) / 100;
             $valid_until = gmdate("Y-m-d\TH:i:s\Z", time() + $duration_in_seconds + $duration_in_seconds * $additional_time_percent);
+        }
+        $url_path = parse_url($url, PHP_URL_PATH);
+        $extension = pathinfo($url_path, PATHINFO_EXTENSION);
+        if ($extension === 'mp4' && !PluginConfig::getConfig(PluginConfig::F_SIGN_PLAYER_LINKS_MP4)) {
+            return $url;
         }
         return self::sign($url, $valid_until, PluginConfig::getConfig(PluginConfig::F_SIGN_PLAYER_LINKS_WITH_IP));
     }

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -79,6 +79,7 @@ config_sign_player_links_overwrite_default#:#Benutze Aufzeichnungsdauer als Daue
 config_sign_player_links_additional_time_percent#:#Zusätzliche Zeit
 config_sign_player_links_additional_time_percent_info#:#Wieviel zusätzliche Zeit soll der Gültigkeit der Signatur in Prozent, abhängig von der Dauer, hinzugefügt werden?
 config_sign_player_links_with_ip#:#Für Client-IP signieren
+config_sign_player_links_mp4#:#Für ".mp4" Dateien signieren
 config_sign_download_links#:#Downloadlink signieren
 config_sign_download_links_info#:#Downloadlinks sind für den Benutzer nicht sichtbar, da der Download via ILIAS-Server getätigt wird.
 config_sign_download_links_time#:#Gültigkeit in Sekunden

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -79,6 +79,7 @@ config_sign_player_links_overwrite_default#:#Use event duration for the validity
 config_sign_player_links_additional_time_percent#:#Additional Time
 config_sign_player_links_additional_time_percent_info#:#How much additional time should be added to the validity of the signature in percent, depending on the event duration?
 config_sign_player_links_with_ip#:#Sign for client IP
+config_sign_player_links_mp4#:#Sign ".mp4" files
 config_sign_download_links#:#Sign Download Link
 config_sign_download_links_info#:#The download links are not visible to the user, because the download is routed via the ILIAS server.
 config_sign_download_links_time#:#Validity in seconds

--- a/src/Model/Config/PluginConfig.php
+++ b/src/Model/Config/PluginConfig.php
@@ -58,6 +58,7 @@ class PluginConfig extends ActiveRecord
     public const F_SIGN_PLAYER_LINKS_OVERWRITE_DEFAULT = 'sign_player_links_overwrite_default';
     public const F_SIGN_PLAYER_LINKS_ADDITIONAL_TIME_PERCENT = "sign_player_links_additional_time_percent";
     public const F_SIGN_PLAYER_LINKS_WITH_IP = "sign_player_links_with_ip";
+    public const F_SIGN_PLAYER_LINKS_MP4 = "sign_player_links_mp4";
     public const F_SIGN_DOWNLOAD_LINKS = 'sign_download_links';
     public const F_SIGN_DOWNLOAD_LINKS_TIME = 'sign_download_links_time';
     public const F_SIGN_THUMBNAIL_LINKS = 'sign_thumbnail_links';


### PR DESCRIPTION
This PR fixes #183

## Description
Please refer to the related issue.

## Solution
- A new option is added to setting menu under Settings > Security > Sign Player Link > Sign mp4 files
- The mentioned setting then check the if the url to sign has mp4 extension and then proceeds with signing.
- On the other hand, I found it not practical that if signing got error the return url is empty, which leads to unseen errors and malfunctions, however the whole plugin has been built with this structure and changing it to throw error is not feasible. Therefore, we decided to only log the error.