### PR TITLE
Fix parsing `ACL` if missing in the API response

### DIFF
--- a/src/Model/Series/SeriesParser.php
+++ b/src/Model/Series/SeriesParser.php
@@ -21,7 +21,7 @@ class SeriesParser
     {
         $series = new Series();
         $series->setIdentifier($data->identifier);
-        $series->setAccessPolicies($this->ACLParser->parseAPIResponse($data->acl));
+        $series->setAccessPolicies($this->ACLParser->parseAPIResponse($data->acl ?? []));
         $series->setMetadata($data->metadata);
         if (is_int($data->theme)) {
             $series->setTheme($data->theme);


### PR DESCRIPTION
See: https://github.com/opencast-ilias/OpenCast/issues/197