### PR TITLE
Fix: Default workflow parameters are ignored when a parameter uses form-based configuration

### DIFF
--- a/classes/Event/class.xoctEventGUI.php
+++ b/classes/Event/class.xoctEventGUI.php
@@ -664,7 +664,7 @@ class xoctEventGUI extends xoctGUI
                     $this->ACLUtils->getBaseACLForUser(xoctUser::getInstance($this->user)),
                     new Processing(
                         PluginConfig::getConfig(PluginConfig::F_WORKFLOW),
-                        $data['workflow_configuration']['object'] ?? $this->getDefaultWorkflowParameters()
+                        $this->getDefaultWorkflowParameters($data['workflow_configuration']['object'])
                     ),
                     xoctUploadFile::getInstanceFromFileArray($data['file']['file'])
                 )
@@ -675,15 +675,16 @@ class xoctEventGUI extends xoctGUI
         $this->ctrl->redirect($this, self::CMD_STANDARD);
     }
 
-    public function getDefaultWorkflowParameters(): \stdClass
+    public function getDefaultWorkflowParameters(?\stdClass $fromData = null): \stdClass
     {
         $WorkflowParameter = new WorkflowParameter();
-        $defaultParameter = new stdClass();
+        $defaultParameter = $fromData ?? new stdClass();
         $admin = ilObjOpenCastAccess::hasPermission('edit_videos');
         foreach ($WorkflowParameter::get() as $param) {
+            $id = $param->getId();
             $defaultValue = $admin ? $param->getDefaultValueAdmin() : $param->getDefaultValueMember();
-            if ($defaultValue == WorkflowParameter::VALUE_ALWAYS_ACTIVE) {
-                $id = $param->getId();
+
+            if (!isset($fromData->$id) && $defaultValue == WorkflowParameter::VALUE_ALWAYS_ACTIVE) {
                 $defaultParameter->$id = "true";
             }
         }


### PR DESCRIPTION
Example Workflow configuration:
![WorkflowParameters](https://github.com/opencast-ilias/OpenCast/assets/11391961/d1764df5-4a13-404c-90f7-4eea6786f66a)

With _publishToCms_ [See 1] configured as Form-Element to be set during Event-Upload, the _publishToIlias_, _publishToEngage_ and _straightToPublishing_ [See 2-4] workflow-parameters are ignore because the presence of the Form-Data ignores any '**Always Active**' parameter. This happens because the in the coresponding code the form-data is not merged with the defaults when creating the Shedule/Prosessing object.

See commit for fix, which uses the default parameters as base and allows Form-Data to overwrite this.