### PR TITLE
Opencast PHP Library upgrade to v1.5.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
   "prefer-stable": true,
   "require": {
     "php": ">=7.3",
-    "elan-ev/opencast-api": "1.4",
+    "elan-ev/opencast-api": "1.5",
     "srag/custominputguis": ">=0.1.0",
     "srag/datatable": ">=0.1.0",
     "srag/dic": ">=0.1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3ec6035552927b2808b955c9ba4217c5",
+    "content-hash": "c514e8f9e82f7cdff520698cb95baa64",
     "packages": [
         {
             "name": "elan-ev/opencast-api",
-            "version": "1.4.0",
+            "version": "1.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/elan-ev/opencast-php-library.git",
-                "reference": "34b46fb9c0986fc7e4ecd05a45038612da7409c9"
+                "reference": "dfcfa0789c8a670623ed27434ced88f595941b73"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/elan-ev/opencast-php-library/zipball/34b46fb9c0986fc7e4ecd05a45038612da7409c9",
-                "reference": "34b46fb9c0986fc7e4ecd05a45038612da7409c9",
+                "url": "https://api.github.com/repos/elan-ev/opencast-php-library/zipball/dfcfa0789c8a670623ed27434ced88f595941b73",
+                "reference": "dfcfa0789c8a670623ed27434ced88f595941b73",
                 "shasum": ""
             },
             "require": {
@@ -61,9 +61,9 @@
             ],
             "support": {
                 "issues": "https://github.com/elan-ev/opencast-php-library/issues",
-                "source": "https://github.com/elan-ev/opencast-php-library/tree/1.4.0"
+                "source": "https://github.com/elan-ev/opencast-php-library/tree/1.5.0"
             },
-            "time": "2023-07-21T11:58:16+00:00"
+            "time": "2023-11-13T16:47:55+00:00"
         },
         {
             "name": "guzzlehttp/guzzle",
@@ -3227,8 +3227,8 @@
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=7.0"
+        "php": ">=7.3"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/src/API/OpencastAPI.php
+++ b/src/API/OpencastAPI.php
@@ -95,9 +95,9 @@ class OpencastAPI implements API
      */
     public function activateIngest(bool $activate): void
     {
-        if ($activate === true && !property_exists($this->api, 'ingest')) {
+        if ($activate === true && $this->api->ingest->object === null) {
             $this->api = $this->decorateApiServicesForXoct($activate);
-        } elseif ($activate === false && property_exists($this->api, 'ingest')) {
+        } elseif ($activate === false && $this->api->ingest->object !== null) {
             $this->api = $this->decorateApiServicesForXoct($activate);
         }
     }

--- a/vendor/composer/installed.json
+++ b/vendor/composer/installed.json
@@ -2,17 +2,17 @@
     "packages": [
         {
             "name": "elan-ev/opencast-api",
-            "version": "1.4.0",
-            "version_normalized": "1.4.0.0",
+            "version": "1.5.0",
+            "version_normalized": "1.5.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/elan-ev/opencast-php-library.git",
-                "reference": "34b46fb9c0986fc7e4ecd05a45038612da7409c9"
+                "reference": "dfcfa0789c8a670623ed27434ced88f595941b73"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/elan-ev/opencast-php-library/zipball/34b46fb9c0986fc7e4ecd05a45038612da7409c9",
-                "reference": "34b46fb9c0986fc7e4ecd05a45038612da7409c9",
+                "url": "https://api.github.com/repos/elan-ev/opencast-php-library/zipball/dfcfa0789c8a670623ed27434ced88f595941b73",
+                "reference": "dfcfa0789c8a670623ed27434ced88f595941b73",
                 "shasum": ""
             },
             "require": {
@@ -24,7 +24,7 @@
                 "phpunit/phpunit": "^9.5",
                 "squizlabs/php_codesniffer": "^3.7"
             },
-            "time": "2023-07-21T11:58:16+00:00",
+            "time": "2023-11-13T16:47:55+00:00",
             "type": "library",
             "extra": {
                 "branch-alias": {
@@ -58,7 +58,7 @@
             ],
             "support": {
                 "issues": "https://github.com/elan-ev/opencast-php-library/issues",
-                "source": "https://github.com/elan-ev/opencast-php-library/tree/1.4.0"
+                "source": "https://github.com/elan-ev/opencast-php-library/tree/1.5.0"
             },
             "install-path": "../elan-ev/opencast-api"
         },

--- a/vendor/composer/installed.php
+++ b/vendor/composer/installed.php
@@ -3,7 +3,7 @@
         'name' => 'opencast-ilias/opencast',
         'pretty_version' => 'dev-main',
         'version' => 'dev-main',
-        'reference' => '2fd8635d1cc1c538e133ee460ec8f324d4bc702f',
+        'reference' => '20b22ab52142ad56559561c1fc34248c73a6fda8',
         'type' => 'project',
         'install_path' => __DIR__ . '/../../',
         'aliases' => array(),
@@ -11,9 +11,9 @@
     ),
     'versions' => array(
         'elan-ev/opencast-api' => array(
-            'pretty_version' => '1.4.0',
-            'version' => '1.4.0.0',
-            'reference' => '34b46fb9c0986fc7e4ecd05a45038612da7409c9',
+            'pretty_version' => '1.5.0',
+            'version' => '1.5.0.0',
+            'reference' => 'dfcfa0789c8a670623ed27434ced88f595941b73',
             'type' => 'library',
             'install_path' => __DIR__ . '/../elan-ev/opencast-api',
             'aliases' => array(),
@@ -49,7 +49,7 @@
         'opencast-ilias/opencast' => array(
             'pretty_version' => 'dev-main',
             'version' => 'dev-main',
-            'reference' => '2fd8635d1cc1c538e133ee460ec8f324d4bc702f',
+            'reference' => '20b22ab52142ad56559561c1fc34248c73a6fda8',
             'type' => 'project',
             'install_path' => __DIR__ . '/../../',
             'aliases' => array(),

--- a/vendor/elan-ev/opencast-api/CHANGELOG.md
+++ b/vendor/elan-ev/opencast-api/CHANGELOG.md
@@ -33,3 +33,6 @@
 - Introducing runAsUser method to add X-RUN-AS-USER into the request headers.
 - Introducing OcListProvidersApi REST API service endpoint.
 - Add another array param into response result of the library called 'origin', which contains the information about oriniated request like its path, base url, params and method.
+
+# 1.5.0
+- PHP 8.2 compatibility: prevent dynamic property declarations

--- a/vendor/elan-ev/opencast-api/src/OpencastApi/Opencast.php
+++ b/vendor/elan-ev/opencast-api/src/OpencastApi/Opencast.php
@@ -6,11 +6,68 @@ use OpencastApi\Rest\OcIngest;
 
 class Opencast
 {
-    /** @var OpencastApi\Rest\OcRestClient the rest client */
+    /** @var OcRestClient the rest client */
     private $restClient;
 
-    /** @var OpencastApi\Rest\OcRestClient the engage node rest client */
+    /** @var OcRestClient the engage node rest client */
     private $engageRestClient;
+
+    // PHP 8.2 deprecates the creation of dynamic class properties.
+    // We also need to avoid the type declaration to provide the possibility of using Decorate proxy.
+
+    /** @var \OpencastApi\Rest\OcAgentsApi $agentsApi */
+    public $agentsApi;
+
+    /** @var \OpencastApi\Rest\OcBaseApi $baseApi */
+    public $baseApi;
+
+    /** @var \OpencastApi\Rest\OcCaptureAdmin $captureAdmin */
+    public $captureAdmin;
+
+    /** @var \OpencastApi\Rest\OcEventAdminNg $eventAdminNg */
+    public $eventAdminNg;
+
+    /** @var \OpencastApi\Rest\OcEventsApi $eventsApi */
+    public $eventsApi;
+
+    /** @var \OpencastApi\Rest\OcGroupsApi $groupsApi */
+    public $groupsApi;
+
+    /** @var \OpencastApi\Rest\OcRecordings $recordings */
+    public $recordings;
+
+    /** @var \OpencastApi\Rest\OcSearch $search */
+    public $search;
+
+    /** @var \OpencastApi\Rest\OcSecurityApi $securityApi */
+    public $securityApi;
+
+    /** @var \OpencastApi\Rest\OcSeriesApi $seriesApi */
+    public $seriesApi;
+
+    /** @var \OpencastApi\Rest\OcSeries $series */
+    public $series;
+
+    /** @var \OpencastApi\Rest\OcServices $services */
+    public $services;
+
+    /** @var \OpencastApi\Rest\OcStatisticsApi $statisticsApi */
+    public $statisticsApi;
+
+    /** @var \OpencastApi\Rest\OcSysinfo $sysinfo */
+    public $sysinfo;
+
+    /** @var \OpencastApi\Rest\OcWorkflow $agentsApi */
+    public $workflow;
+
+    /** @var \OpencastApi\Rest\OcWorkflowsApi $workflowsApi */
+    public $workflowsApi;
+
+    /** @var \OpencastApi\Rest\OcIngest $ingest */
+    public $ingest;
+
+    /** @var \OpencastApi\Rest\OcListProvidersApi $listProvidersApi */
+    public $listProvidersApi;
 
     /*
         $config = [
@@ -55,7 +112,7 @@ class Opencast
             $propertyName = lcfirst(str_replace('Oc', '', $className));
             $client = $this->restClient;
 
-            if (in_array($className, $this->excludeFilters()) || property_exists($this, $propertyName)) {
+            if (in_array($className, $this->excludeFilters())) {
                 continue;
             }
 
@@ -63,7 +120,10 @@ class Opencast
                 $client = $this->engageRestClient;
             }
 
-            $this->{$propertyName} = new $fullClassName($client);
+            // Make sure the property is declared properly!
+            if (property_exists($this, $propertyName)) {
+                $this->{$propertyName} = new $fullClassName($client);
+            }
         }
 
         if ($enableingest) {
@@ -133,7 +193,10 @@ class Opencast
                 $ingestClient = new OcRestClient($config);
             }
 
-            $this->ingest = new OcIngest($ingestClient);
+            // Make sure ingest property exists!
+            if (property_exists($this, 'ingest')) {
+                $this->ingest = new OcIngest($ingestClient);
+            }
         }
     }
 

--- a/vendor/elan-ev/opencast-api/tests/Unit/OcListProvidersApiTest.php
+++ b/vendor/elan-ev/opencast-api/tests/Unit/OcListProvidersApiTest.php
@@ -26,8 +26,9 @@ class OcListProvidersApiTest extends TestCase
         $this->assertSame(200, $response['code'], 'failure to get providers list');
         $providers = $response['body'];
         if (!empty($providers) && is_array($providers)) {
+            $providers = count($providers) == 1 ? reset($providers) : $providers;
             $provider = $providers[array_rand($providers)];
-            $responseList = $this->ocListProvidersApi->get($provider);
+            $responseList = $this->ocListProvidersApi->getList($provider);
             $this->assertSame(200, $responseList['code'], 'failure to get provider list');
         } else {
             $this->markTestIncomplete('No provider to complete the test!');


### PR DESCRIPTION
This PR only upgrades the Opencast PHP Library to the latest version (v.1.5.0) which contains PHP 8.2 compatibility improvement: deprecated dynamic property declaration