### PR TITLE
Master playlist priority

### DIFF
--- a/src/Util/Player/StandardPlayerDataBuilder.php
+++ b/src/Util/Player/StandardPlayerDataBuilder.php
@@ -167,13 +167,23 @@ class StandardPlayerDataBuilder extends PlayerDataBuilder
             publicationMetadata::ROLE_PRESENTATION => []
         ];
 
+        $source_type_master_mapping = [];
         foreach ($media as $medium) {
             $duration = $duration ?: $medium->getDuration();
             $source_type = self::$mimetype_mapping[$medium->getMediatype()];
             if (!is_array($sources[$medium->getRole()][$source_type])) {
                 $sources[$medium->getRole()][$source_type] = [];
             }
-            $sources[$medium->getRole()][$source_type][] = $this->buildSource($medium, $duration);
+
+            $is_master_playlist = $medium->isMasterPlaylist();
+            if ($is_master_playlist) {
+                $source_type_master_mapping[$source_type] = true;
+                $sources[$medium->getRole()][$source_type] = [];
+            }
+
+            if ($is_master_playlist || empty($source_type_master_mapping[$source_type])) {
+                $sources[$medium->getRole()][$source_type][] = $this->buildSource($medium, $duration);
+            }
         }
 
         foreach ($sources as $role => $source) {


### PR DESCRIPTION
This PR fixes #239,

## Description
please refer to issue

### Solution
It appears that Paella Player extracts the quality of an `HLS` video from the master playlist, unlike the `MP4` type, which considers the several qualities of a video by the number of videos appear in the stream src property.
Hence, it is important to only pass master playlist when exists (for MP4 there will never be a master playlist therefore it is also safe as the PR works as normal)


### Extras
each of the current development processes has now the same PR:
- This PR for feature/8/refactoring: https://github.com/srsolutionsag/OpenCast/pull/3
- This PR for feature/7/refactoring: https://github.com/srsolutionsag/OpenCast/pull/2