### PR TITLE
[Release 8][Fix] Escape non-strings in prefill replacement

### DIFF
--- a/src/Model/Metadata/Helper/MDPrefiller.php
+++ b/src/Model/Metadata/Helper/MDPrefiller.php
@@ -204,7 +204,7 @@ class MDPrefiller
                     }
                 }
                 if (!is_null($replacement)) {
-                    $prefilled_replaced_text = str_replace($match, $replacement, $prefilled_replaced_text);
+                    $prefilled_replaced_text = str_replace($match, (string) $replacement, $prefilled_replaced_text);
                 }
             }
         }


### PR DESCRIPTION
This PR fixes #263 

### Description
please refer to issue.

### Solution
adding a string type casting solves the problem!