### PR TITLE
fix livestream playback issues by removing hlsConfig options

### DIFF
--- a/js/opencast/src/Paella/config/config.json
+++ b/js/opencast/src/Paella/config/config.json
@@ -197,11 +197,7 @@
       "hlsConfig": {
         "enableWorker": true,
         "lowLatencyMode": true,
-        "maxBufferLength": 10,
-        "liveSyncDuration": 3,
-        "liveMaxLatencyDuration": 6,
-        "liveDurationInfinity": true,
-        "highBufferWatchdogPeriod": 1
+        "liveDurationInfinity": true
       },
       "corsConfig": {
         "withCredentials": false,


### PR DESCRIPTION
this removes hlsConfig options that are not recommended 
instead we use the defaults from hlsConfig by not defining those options 
liveSyncDurationCount: 3
highBufferWatchdogPeriod: 3
maxBufferLength: 30

fixes https://github.com/opencast-ilias/OpenCast/issues/286