### PR TITLE
[Release 8] Upgrade OC-PHP-LIB (v1.7)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
   "require": {
     "php": ">=7.3",
     "ext-dom": "*",
-    "elan-ev/opencast-api": "1.6"
+    "elan-ev/opencast-api": "1.7"
   },
   "autoload": {
     "exclude-from-classmap": ["vendor/guzzlehttp/", "vendor/ralouphie/", "vendor/psr/http-message", "vendor/psr/http-factory", "vendor/psr/http-client"],

--- a/composer.lock
+++ b/composer.lock
@@ -4,24 +4,24 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bf0351c5354f85225495e670a9986f92",
+    "content-hash": "666f5a908e1ad3bd55e456c75e0f2eaf",
     "packages": [
         {
             "name": "elan-ev/opencast-api",
-            "version": "1.6.0",
+            "version": "1.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/elan-ev/opencast-php-library.git",
-                "reference": "4209600ff4690b9b35363703d297f2f2660fae57"
+                "reference": "34dee9ad29c6059d6ec913438c48c3f3e6721b5c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/elan-ev/opencast-php-library/zipball/4209600ff4690b9b35363703d297f2f2660fae57",
-                "reference": "4209600ff4690b9b35363703d297f2f2660fae57",
+                "url": "https://api.github.com/repos/elan-ev/opencast-php-library/zipball/34dee9ad29c6059d6ec913438c48c3f3e6721b5c",
+                "reference": "34dee9ad29c6059d6ec913438c48c3f3e6721b5c",
                 "shasum": ""
             },
             "require": {
-                "guzzlehttp/guzzle": "7.5.1",
+                "guzzlehttp/guzzle": ">=7.5.1",
                 "php": ">=7.2.5"
             },
             "require-dev": {
@@ -61,9 +61,9 @@
             ],
             "support": {
                 "issues": "https://github.com/elan-ev/opencast-php-library/issues",
-                "source": "https://github.com/elan-ev/opencast-php-library/tree/1.6.0"
+                "source": "https://github.com/elan-ev/opencast-php-library/tree/1.7.0"
             },
-            "time": "2024-04-24T13:34:24+00:00"
+            "time": "2024-06-13T12:41:49+00:00"
         },
         {
             "name": "guzzlehttp/guzzle",

--- a/vendor/composer/installed.json
+++ b/vendor/composer/installed.json
@@ -2,21 +2,21 @@
     "packages": [
         {
             "name": "elan-ev/opencast-api",
-            "version": "1.6.0",
-            "version_normalized": "1.6.0.0",
+            "version": "1.7.0",
+            "version_normalized": "1.7.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/elan-ev/opencast-php-library.git",
-                "reference": "4209600ff4690b9b35363703d297f2f2660fae57"
+                "reference": "34dee9ad29c6059d6ec913438c48c3f3e6721b5c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/elan-ev/opencast-php-library/zipball/4209600ff4690b9b35363703d297f2f2660fae57",
-                "reference": "4209600ff4690b9b35363703d297f2f2660fae57",
+                "url": "https://api.github.com/repos/elan-ev/opencast-php-library/zipball/34dee9ad29c6059d6ec913438c48c3f3e6721b5c",
+                "reference": "34dee9ad29c6059d6ec913438c48c3f3e6721b5c",
                 "shasum": ""
             },
             "require": {
-                "guzzlehttp/guzzle": "7.5.1",
+                "guzzlehttp/guzzle": ">=7.5.1",
                 "php": ">=7.2.5"
             },
             "require-dev": {
@@ -24,7 +24,7 @@
                 "phpunit/phpunit": "^9.5",
                 "squizlabs/php_codesniffer": "^3.7"
             },
-            "time": "2024-04-24T13:34:24+00:00",
+            "time": "2024-06-13T12:41:49+00:00",
             "type": "library",
             "extra": {
                 "branch-alias": {
@@ -58,7 +58,7 @@
             ],
             "support": {
                 "issues": "https://github.com/elan-ev/opencast-php-library/issues",
-                "source": "https://github.com/elan-ev/opencast-php-library/tree/1.6.0"
+                "source": "https://github.com/elan-ev/opencast-php-library/tree/1.7.0"
             },
             "install-path": "../elan-ev/opencast-api"
         },

--- a/vendor/composer/installed.php
+++ b/vendor/composer/installed.php
@@ -3,7 +3,7 @@
         'name' => 'opencast-ilias/opencast',
         'pretty_version' => 'dev-main',
         'version' => 'dev-main',
-        'reference' => '598397ddb9f7b18f6624e6fb054bac20eb943c71',
+        'reference' => '2028d7230ad494717cca8b83dc50787922c8b1f7',
         'type' => 'project',
         'install_path' => __DIR__ . '/../../',
         'aliases' => array(),
@@ -11,9 +11,9 @@
     ),
     'versions' => array(
         'elan-ev/opencast-api' => array(
-            'pretty_version' => '1.6.0',
-            'version' => '1.6.0.0',
-            'reference' => '4209600ff4690b9b35363703d297f2f2660fae57',
+            'pretty_version' => '1.7.0',
+            'version' => '1.7.0.0',
+            'reference' => '34dee9ad29c6059d6ec913438c48c3f3e6721b5c',
             'type' => 'library',
             'install_path' => __DIR__ . '/../elan-ev/opencast-api',
             'aliases' => array(),
@@ -49,7 +49,7 @@
         'opencast-ilias/opencast' => array(
             'pretty_version' => 'dev-main',
             'version' => 'dev-main',
-            'reference' => '598397ddb9f7b18f6624e6fb054bac20eb943c71',
+            'reference' => '2028d7230ad494717cca8b83dc50787922c8b1f7',
             'type' => 'project',
             'install_path' => __DIR__ . '/../../',
             'aliases' => array(),

--- a/vendor/elan-ev/opencast-api/CHANGELOG.md
+++ b/vendor/elan-ev/opencast-api/CHANGELOG.md
@@ -36,3 +36,14 @@
 
 # 1.5.0
 - PHP 8.2 compatibility: prevent dynamic property declarations
+
+# 1.6.0
+- Introducing OcPlaylistApi REST API service endpoint.
+- Fix ingest tags issues
+
+# 1.7.0
+- Adopt Opencast 16 changes (lucene search endpoint removal by toggle it in the config -> features -> lucene [default false])
+- runWithRoles does not apply the headers when api version is not defined
+- Playlist endpoint minor changes
+- Add workflow configuration params into ingest method.
+- Make guzzle version require from (>=) v7.5.1 in composer.

--- a/vendor/elan-ev/opencast-api/README.md
+++ b/vendor/elan-ev/opencast-api/README.md
@@ -26,6 +26,7 @@ $config = [
       'connect_timeout' => 0,                         // The API connection timeout. In seconds (default 0 to wait indefinitely) (optional)
       'version' => null,                              // The API Version. (Default null). (optional)
       'handler' => null                               // The callable Handler or HandlerStack. (Default null). (optional)
+      'features' => null                              // A set of additional features [e.g. lucene search]. (Default null). (optional)
 ];
 
 $engageConfig = [
@@ -36,6 +37,7 @@ $engageConfig = [
       'connect_timeout' => 0,                         // The API connection timeout. In seconds (default 0 to wait indefinitely) (optional)
       'version' => null,                              // The API version. (Default null). (optional)
       'handler' => null                               // The callable Handler or HandlerStack. (Default null). (optional)
+      'features' => null                              // A set of additional features [e.g. lucene search]. (Default null). (optional)
 ];
 
 use OpencastApi\Opencast;
@@ -73,6 +75,7 @@ $config = [
       'connect_timeout' => 0,                         // The API connection timeout. In seconds (default 0 to wait indefinitely) (optional)
       'version' => null,                              // The API version. (Default null). (optional)
       'handler' => null                               // The callable Handler or HandlerStack. (Default null). (optional)
+      'features' => null                              // A set of additional features [e.g. lucene search]. (Default null). (optional)
 ];
 
 
@@ -112,8 +115,11 @@ $config = [
       'connect_timeout' => 0,                         // The API connection timeout. In seconds (default 0 to wait indefinitely) (optional)
       'version' => null,                              // The API version. (Default null). (optional)
       'handler' => null                               // The callable Handler or HandlerStack. (Default null). (optional)
+      'features' => null                              // A set of additional features [e.g. lucene search]. (Default null). (optional)
 ];
 ```
+**UPDATE (v1.7.0):** the new items called `features` is added to the configuration array. As of now, it is meant to hanlde the toggle behavior to enable/disable Lucene search endpoint simply by adding `'features' => ['lucene' => true]`. Just keep in mind that this endpoint id off by default and won't work in Opencast 16 onwards. Therefore, developer must be very careful to use this feature and to toggle it!
+
 NOTE: the configuration for presentation (`engage` node) responsible for search has to follow the same definition as normal config. But in case any parameter is missing, the value will be taken from the main config param.
 
 #### Extra: Dynamically loading the ingest endpoint class into Opencast instance.

--- a/vendor/elan-ev/opencast-api/composer.json
+++ b/vendor/elan-ev/opencast-api/composer.json
@@ -19,7 +19,7 @@
     "homepage": "https://docs.opencast.org/",
     "require": {
         "php": ">=7.2.5",
-        "guzzlehttp/guzzle": "7.5.1"
+        "guzzlehttp/guzzle": ">=7.5.1"
     },
     "autoload": {
         "psr-4": {

--- a/vendor/elan-ev/opencast-api/src/OpencastApi/Opencast.php
+++ b/vendor/elan-ev/opencast-api/src/OpencastApi/Opencast.php
@@ -81,6 +81,7 @@ class Opencast
             'connect_timeout' => 0                          // The API connection timeout. In seconds (default 0 to wait indefinitely) (optional)
             'version' => null                               // The API Version. (Default null). (optional)
             'handler' => null                               // The callable Handler or HandlerStack. (Default null). (optional)
+            'features' => null                              // A set of additional features [e.g. lucene search]. (Default null). (optional)
         ]
 
         $engageConfig = [
@@ -91,6 +92,7 @@ class Opencast
             'connect_timeout' => 0                          // The API connection timeout. In seconds (default 0 to wait indefinitely) (optional)
             'version' => null                               // The API Version. (Default null). (optional)
             'handler' => null                               // The callable Handler or HandlerStack. (Default null). (optional)
+            'features' => null                              // A set of additional features [e.g. lucene search]. (Default null). (optional)
         ]
     */
     /**
@@ -170,6 +172,9 @@ class Opencast
         }
         if (!isset($engageConfig['handler']) && isset($config['handler'])) {
             $engageConfig['handler'] = $config['handler'];
+        }
+        if (!isset($engageConfig['features']) && isset($config['features'])) {
+            $engageConfig['features'] = $config['features'];
         }
         $this->engageRestClient = new OcRestClient($engageConfig);
     }

--- a/vendor/elan-ev/opencast-api/src/OpencastApi/Rest/OcIngest.php
+++ b/vendor/elan-ev/opencast-api/src/OpencastApi/Rest/OcIngest.php
@@ -431,10 +431,11 @@ class OcIngest extends OcRest
      * @param string $mediaPackage The media package
      * @param string $workflowDefinitionId (optional) Workflow definition id
      * @param string $workflowInstanceId (optional) The workflow instance ID to associate this ingest with scheduled events.
+     * @param array $workflowConfiguration Workflow configuration
      *
      * @return array the response result ['code' => 200, 'body' => '{XML (text) media package}']
      */
-    public function ingest($mediaPackage, $workflowDefinitionId = '', $workflowInstanceId = '')
+    public function ingest($mediaPackage, $workflowDefinitionId = '', $workflowInstanceId = '', $workflowConfiguration = [])
     {
         $uri = self::URI . "/ingest";
         if (!empty($workflowDefinitionId) && empty($workflowInstanceId)) {
@@ -448,6 +449,13 @@ class OcIngest extends OcRest
         if (!empty($workflowDefinitionId) && !empty($workflowInstanceId)) {
             $formData['workflowDefinitionId'] = $workflowDefinitionId;
             $formData['workflowInstanceId'] = $workflowInstanceId;
+        }
+
+        if (!empty($workflowConfiguration)) {
+            // Adding workflow configuration params into the form data one by one.
+            foreach ($workflowConfiguration as $config => $value) {
+                $formData[$config] = $value;
+            }
         }
 
         $options = $this->restClient->getFormParams($formData);

--- a/vendor/elan-ev/opencast-api/src/OpencastApi/Rest/OcPlaylistsApi.php
+++ b/vendor/elan-ev/opencast-api/src/OpencastApi/Rest/OcPlaylistsApi.php
@@ -132,14 +132,16 @@ class OcPlaylistsApi extends OcRest
      */
     public function updateEntries($playlistId, $playlistEntries)
     {
-        $uri = self::URI . "/{$playlistId}/entries";
+        $uri = self::URI . "/{$playlistId}";
 
         $formData = [
-            'playlistEntries' => $playlistEntries,
+            'playlist' => [
+                'entries' => $playlistEntries
+            ]
         ];
 
         $options = $this->restClient->getFormParams($formData);
-        return $this->restClient->performPost($uri, $options);
+        return $this->restClient->performPut($uri, $options);
     }
 
     /**

--- a/vendor/elan-ev/opencast-api/src/OpencastApi/Rest/OcSearch.php
+++ b/vendor/elan-ev/opencast-api/src/OpencastApi/Rest/OcSearch.php
@@ -1,21 +1,25 @@
-<?php 
+<?php
 namespace OpencastApi\Rest;
 
 class OcSearch extends OcRest
 {
     const URI = '/search';
+    public $lucene = false; // By default false, main support for OC 16.
 
     public function __construct($restClient)
     {
         $restClient->registerHeaderException('Accept', self::URI);
         parent::__construct($restClient);
+        if ($restClient->readFeatures('lucene')) {
+            $this->lucene = true;
+        }
     }
 
-    
+
     /**
      * Search for episodes matching the query parameters as object (JSON) by default or XML (text) on demand.
-     * 
-     * @param array $params the params to pass to the call: it must cointain the following: 
+     *
+     * @param array $params the params to pass to the call: it must cointain the following:
      * $params = [
      *      'id' => '{The ID of the single episode to be returned, if it exists}',
      *      'q' => '{Any episode that matches this free-text query.}',
@@ -28,7 +32,7 @@ class OcSearch extends OcRest
      *      'sign' => '{If results are to be signed (Default value=true)}',
      * ]
      * @param string $format The output format (json or xml) of the response body. (Default value = 'json')
-     * 
+     *
      * @return array the response result ['code' => 200, 'body' => '{The search results, formatted as xml or json}']
      */
     public function getEpisodes($params = [], $format = '')
@@ -64,30 +68,58 @@ class OcSearch extends OcRest
             $query['sign'] = $params['sign'];
         }
 
-        $sortsASC = [
-            'DATE_CREATED', 'DATE_MODIFIED', 'TITLE', 'SERIES_ID',
-            'MEDIA_PACKAGE_ID', 'CREATOR', 'CONTRIBUTOR', 'LANGUAGE',
-            'LICENSE','SUBJECT','DESCRIPTION','PUBLISHER',
-        ];
-        $sortsDESC = array_map(function ($sort) {
-            return "{$sort}_DESC";
-        }, $sortsASC);
 
-        $sorts = array_merge($sortsASC, $sortsDESC);
-        
-        if (array_key_exists('sort', $params) && !empty($params['sort']) &&
-            in_array($params['sort'], $sorts)) {
-            $query['sort'] = $params['sort'];
+        // OC <= 15
+        if ($this->lucene) {
+            $sortsASC = [
+                'DATE_CREATED', 'DATE_MODIFIED', 'TITLE', 'SERIES_ID',
+                'MEDIA_PACKAGE_ID', 'CREATOR', 'CONTRIBUTOR', 'LANGUAGE',
+                'LICENSE','SUBJECT','DESCRIPTION','PUBLISHER',
+            ];
+            $sortsDESC = array_map(function ($sort) {
+                return "{$sort}_DESC";
+            }, $sortsASC);
+
+            $sorts = array_merge($sortsASC, $sortsDESC);
+
+            if (array_key_exists('sort', $params) && !empty($params['sort']) &&
+                in_array($params['sort'], $sorts)) {
+                $query['sort'] = $params['sort'];
+            }
+
+        // OC >= 16
+        } else {
+            $sorts = [
+                'modified', 'title', 'creator', 'contributor'
+            ];
+
+            $sortsASC = array_map(function ($sort) {
+                return "{$sort} asc";
+            }, $sorts);
+
+            $sortsDESC = array_map(function ($sort) {
+                return "{$sort} desc";
+            }, $sorts);
+
+            $sorts_list = array_merge($sorts, $sortsASC, $sortsDESC);
+
+            if (array_key_exists('sort', $params) && !empty($params['sort']) &&
+                in_array(strtolower($params['sort']), $sorts_list)) {
+                $query['sort'] = strtolower($params['sort']);
+            }
         }
-        
+
         $options = $this->restClient->getQueryParams($query);
         return $this->restClient->performGet($uri, $options);
     }
 
+
     /**
      * Search a lucene query as object (JSON) by default or XML (text) on demand.
-     * 
-     * @param array $params the params to pass to the call: it must cointain the following: 
+     *
+     * INFO: This endpoint is removed in Opencast 16.
+     *
+     * @param array $params the params to pass to the call: it must cointain the following:
      * $params = [
      *      'q' => '{ The lucene query. }',
      *      'series' => '{ Include series in the search result. (Default value=false)}',
@@ -98,11 +130,15 @@ class OcSearch extends OcRest
      *      'sign' => '{If results are to be signed (Default value=true)}',
      * ]
      * @param string $format The output format (json or xml) of the response body. (Default value = 'json')
-     * 
+     *
      * @return array the response result ['code' => 200, 'body' => '{The search results, formatted as xml or json}']
      */
     public function getLucene($params = [], $format = '')
     {
+        if (!$this->lucene) {
+            return ['code' => 410, 'reason' => 'Lucene search endpoint is not available!'];
+        }
+
         $uri = self::URI . "/lucene.json";
         if (!empty($format) && strtolower($format) == 'xml') {
             $uri = str_replace('json', 'xml', $uri);
@@ -138,20 +174,20 @@ class OcSearch extends OcRest
         }, $sortsASC);
 
         $sorts = array_merge($sortsASC, $sortsDESC);
-        
+
         if (array_key_exists('sort', $params) && !empty($params['sort']) &&
             in_array($params['sort'], $sorts)) {
             $query['sort'] = $params['sort'];
         }
-        
+
         $options = $this->restClient->getQueryParams($query);
         return $this->restClient->performGet($uri, $options);
     }
 
     /**
      * Search for series matching the query parameters and returns JSON (object) by default or XML (text) on demand
-     * 
-     * @param array $params the params to pass to the call: it must cointain the following: 
+     *
+     * @param array $params the params to pass to the call: it must cointain the following:
      * $params = [
      *      'id' = '{The series ID. If the additional boolean parameter "episodes" is "true", the result set will include this series episodes.}'
      *      'q' => '{Any series that matches this free-text query. If the additional boolean parameter "episodes" is "true", the result set will include this series episodes.}',
@@ -163,7 +199,7 @@ class OcSearch extends OcRest
      *      'sign' => '{If results are to be signed (Default value=true)}',
      * ]
      * @param string $format The output format (json or xml) of the response body. (Default value = 'json')
-     * 
+     *
      * @return array the response result ['code' => 200, 'body' => '{The search results, formatted as xml or json}']
      */
     public function getSeries($params = [], $format = '')
@@ -196,22 +232,46 @@ class OcSearch extends OcRest
             $query['sign'] = $params['sign'];
         }
 
-        $sortsASC = [
-            'DATE_CREATED', 'DATE_MODIFIED', 'TITLE', 'SERIES_ID',
-            'MEDIA_PACKAGE_ID', 'CREATOR', 'CONTRIBUTOR', 'LANGUAGE',
-            'LICENSE','SUBJECT','DESCRIPTION','PUBLISHER',
-        ];
-        $sortsDESC = array_map(function ($sort) {
-            return "{$sort}_DESC";
-        }, $sortsASC);
+        // OC <= 15
+        if ($this->lucene) {
+            $sortsASC = [
+                'DATE_CREATED', 'DATE_MODIFIED', 'TITLE', 'SERIES_ID',
+                'MEDIA_PACKAGE_ID', 'CREATOR', 'CONTRIBUTOR', 'LANGUAGE',
+                'LICENSE','SUBJECT','DESCRIPTION','PUBLISHER',
+            ];
+            $sortsDESC = array_map(function ($sort) {
+                return "{$sort}_DESC";
+            }, $sortsASC);
 
-        $sorts = array_merge($sortsASC, $sortsDESC);
-        
-        if (array_key_exists('sort', $params) && !empty($params['sort']) &&
-            in_array($params['sort'], $sorts)) {
-            $query['sort'] = $params['sort'];
+            $sorts = array_merge($sortsASC, $sortsDESC);
+
+            if (array_key_exists('sort', $params) && !empty($params['sort']) &&
+                in_array($params['sort'], $sorts)) {
+                $query['sort'] = $params['sort'];
+            }
+
+        // OC >= 16
+        } else {
+            $sorts = [
+                'modified', 'title', 'creator', 'contributor'
+            ];
+
+            $sortsASC = array_map(function ($sort) {
+                return "{$sort} asc";
+            }, $sorts);
+
+            $sortsDESC = array_map(function ($sort) {
+                return "{$sort} desc";
+            }, $sorts);
+
+            $sorts_list = array_merge($sorts, $sortsASC, $sortsDESC);
+
+            if (array_key_exists('sort', $params) && !empty($params['sort']) &&
+                in_array(strtolower($params['sort']), $sorts_list)) {
+                $query['sort'] = strtolower($params['sort']);
+            }
         }
-        
+
         $options = $this->restClient->getQueryParams($query);
         return $this->restClient->performGet($uri, $options);
     }

--- a/vendor/elan-ev/opencast-api/tests/DataProvider/PlaylistsDataProvider.php
+++ b/vendor/elan-ev/opencast-api/tests/DataProvider/PlaylistsDataProvider.php
@@ -20,7 +20,7 @@ class PlaylistsDataProvider {
 
     public static function getEntries()
     {
-        return '[{"contentId":"ID-about-opencast","type":"EVENT"},{"contentId":"ID-3d-print","type":"EVENT"}]';
+        return json_decode('[{"contentId":"ID-about-opencast","type":"EVENT"},{"contentId":"ID-3d-print","type":"EVENT"}]');
     }
 }
 ?>

--- a/vendor/elan-ev/opencast-api/tests/DataProvider/SearchDataProvider.php
+++ b/vendor/elan-ev/opencast-api/tests/DataProvider/SearchDataProvider.php
@@ -1,18 +1,16 @@
-<?php 
+<?php
 namespace Tests\DataProvider;
 
 class SearchDataProvider {
-    
+
     public static function getEpisodeQueryCases(): array
     {
         return [
             [[], 'json'],
-            [[], 'xml'],
-            [[], 'XML'],
             [['id' => 'fe0b45b0-7ed5-4944-8b0a-a0a283331791'], ''],
             [['sid' => '8010876e-1dce-4d38-ab8d-24b956e3d8b7'], ''],
             [['sname' => 'HUB_LOCAL_TEST'], ''],
-            [['sort' => 'DATE_CREATED_DESC'], ''],
+            [['sort' => 'modified asc'], ''],
             [['offset' => 1], ''],
             [['limit' => 1], ''],
             [['admin' => true], ''],
@@ -39,11 +37,9 @@ class SearchDataProvider {
     {
         return [
             [[], 'json'],
-            [[], 'xml'],
-            [[], 'XML'],
             [['id' => '8010876e-1dce-4d38-ab8d-24b956e3d8b7'], ''],
             [['episodes' => true], ''],
-            [['sort' => 'DATE_CREATED_DESC'], ''],
+            [['sort' => 'modified desc'], ''],
             [['offset' => 1], ''],
             [['limit' => 1], ''],
             [['admin' => true], ''],

--- a/vendor/elan-ev/opencast-api/tests/DataProvider/SetupDataProvider.php
+++ b/vendor/elan-ev/opencast-api/tests/DataProvider/SetupDataProvider.php
@@ -15,8 +15,11 @@ class SetupDataProvider {
             'username' => $username,
             'password' => $password,
             'timeout' => $timeout,
-            'version' => '1.9.0',
-            'connect_timeout' => $connectTimeout
+            'version' => '1.11.0',
+            'connect_timeout' => $connectTimeout,
+            'features' => [
+                'lucene' => false
+            ]
         ];
         if (!empty($version)) {
             $config['version'] = $version;

--- a/vendor/elan-ev/opencast-api/tests/Unit/OcIngestTest.php
+++ b/vendor/elan-ev/opencast-api/tests/Unit/OcIngestTest.php
@@ -206,7 +206,11 @@ class OcIngestTest extends TestCase
     public function ingest(array $ingestData): void
     {
         $workflowDefinitionId = 'schedule-and-upload';
-        $responseIngest = $this->ocIngest->ingest($ingestData['mediaPackage'], $workflowDefinitionId);
+        // Add workflow configuration params.
+        $workflowConfiguration = [
+            'straightToPublishing' => false
+        ];
+        $responseIngest = $this->ocIngest->ingest($ingestData['mediaPackage'], $workflowDefinitionId, '', $workflowConfiguration);
         $this->assertSame(200, $responseIngest['code'], 'Failure to ingest');
         $mediaPackage = $responseIngest['body'];
         $this->assertNotEmpty($mediaPackage);

--- a/vendor/elan-ev/opencast-api/tests/Unit/OcSearchTest.php
+++ b/vendor/elan-ev/opencast-api/tests/Unit/OcSearchTest.php
@@ -28,22 +28,22 @@ class OcSearchTest extends TestCase
 
     /**
      * @test
-     * @dataProvider \Tests\DataProvider\SearchDataProvider::getLuceneQueryCases()
-     */
-    public function get_lucenes($params, $format): void
-    {
-        $response = $this->ocSearch->getLucene($params, $format);
-        $this->assertSame(200, $response['code'], 'Failure to search lucene');
-    }
-
-    /**
-     * @test
      * @dataProvider \Tests\DataProvider\SearchDataProvider::getSeriesQueryCases()
      */
     public function get_series($params, $format): void
     {
         $response = $this->ocSearch->getSeries($params, $format);
         $this->assertSame(200, $response['code'], 'Failure to search series');
+    }
+
+    /**
+     * @test
+     * @dataProvider \Tests\DataProvider\SearchDataProvider::getLuceneQueryCases()
+     */
+    public function get_lucenes($params, $format): void
+    {
+        $response = $this->ocSearch->getLucene($params, $format);
+        $this->assertContains($response['code'], [200, 410], 'Failure to create an event');
     }
 }
 ?>

--- a/vendor/elan-ev/opencast-api/tests/UnitMock/OcSearchTestMock.php
+++ b/vendor/elan-ev/opencast-api/tests/UnitMock/OcSearchTestMock.php
@@ -37,10 +37,10 @@ class OcSearchTestMock extends TestCase
      * @test
      */
     public function get_lucenes(): void
-    {
+{
         $params = ['series' => true];
         $response = $this->ocSearch->getLucene($params);
-        $this->assertSame(200, $response['code'], 'Failure to search lucene');
+        $this->assertContains($response['code'], [200, 410], 'Failure to create an event');
     }
 
     /**


### PR DESCRIPTION
This PR fixes #298 

List of changes: 
- https://github.com/elan-ev/opencast-php-library/releases/tag/1.7.0
- https://github.com/elan-ev/opencast-php-library/milestone/5?closed=1

This upgrade contains a required dependency for #291 and #10, in order to pass workflow parameters to ingest.

This also makes the plugin compatible with Opencast 16!

The release_7 PR follows... 

**IMPORTANT:** Performing basic tests would be a good practice.