### PR TITLE
[Release 8] Upload Thumbnail (Preview) 

### DIFF
--- a/classes/class.xoctMainGUI.php
+++ b/classes/class.xoctMainGUI.php
@@ -33,6 +33,9 @@ class xoctMainGUI extends xoctGUI
 
     public const SUBTAB_WORKFLOWS_SETTINGS = 'wf_settings';
     public const SUBTAB_WORKFLOWS_LIST = 'wf_list';
+
+    public const SUBTAB_THUMBNAILS = 'thumbnails';
+
     /**
      * @var \ilTabsGUI
      */
@@ -149,7 +152,8 @@ class xoctMainGUI extends xoctGUI
                 $xoctConfGUI = new xoctConfGUI(
                     $DIC->ui()->renderer(),
                     $opencast_dic->paella_config_upload_handler(),
-                    $opencast_dic->paella_config_form_builder()
+                    $opencast_dic->paella_config_form_builder(),
+                    $opencast_dic->thumbnail_config_form_builder()
                 );
                 $this->ctrl->forwardCommand($xoctConfGUI);
                 break;
@@ -175,6 +179,12 @@ class xoctMainGUI extends xoctGUI
             self::SUBTAB_PLAYER,
             $this->plugin->txt('subtab_' . self::SUBTAB_PLAYER),
             $this->ctrl->getLinkTargetByClass(xoctConfGUI::class, 'player')
+        );
+        $this->ctrl->setParameterByClass(xoctConfGUI::class, 'subtab_active', self::SUBTAB_THUMBNAILS);
+        $this->tabs->addSubTab(
+            self::SUBTAB_THUMBNAILS,
+            $this->plugin->txt('subtab_' . self::SUBTAB_THUMBNAILS),
+            $this->ctrl->getLinkTargetByClass(xoctConfGUI::class, xoctConfGUI::CMD_THUMBNAIL)
         );
         $this->ctrl->setParameterByClass(xoctConfGUI::class, 'subtab_active', self::SUBTAB_TOU);
         $this->tabs->addSubTab(

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -733,3 +733,24 @@ config_paella_player_section_preview#:#Preview
 config_paella_player_section_caption#:#Caption
 config_paella_player_prevent_video_download#:#Video-Download verhindern
 config_paella_player_prevent_video_download_info#:#Wenn diese Option aktiviert ist, wird das direkte Herunterladen von Videos vom Player verhindert. <br> Dies können Sie erreichen, indem Sie mit der rechten Maustaste auf das Video klicken und "Video speichern unter" oder ähnliches auswählen.
+subtab_thumbnails#:#Vorschaubilder
+config_thumbnail_upload_enabled#:#Vorschaubilder hochladen aktivieren
+config_thumbnail_upload_enabled_info#:#Durch Aktivieren dieser Option wird das Hochladen des Vorschaubild zusammen mit dem Video in der Upload-Seite ermöglicht.<br><strong>Achtung:</strong> Damit diese Funktion funktioniert, muss der Workflow-Parameter "straightToPublishing" standardmäßig aktiviert sein. Denn wenn "straightToPublishing" deaktiviert ist, wird das Event in den Schnittmodus versetzt, in dem kein Vorschaubildprozess ausgeführt wird.
+config_thumbnail_accepted_mimetypes#:#Akzeptierte Dateitypen
+config_thumbnail_accepted_mimetypes_info#:#Liste der akzeptierten Erweiterungen der Vorschaubilddatei, die Benutzer hochladen dürfen.
+config_thumbnail_upload_mode#:#Upload-Modus
+config_thumbnail_upload_mode_info#:#Die Auswahl einer Option führt dazu, dass auf der Video-Upload-Seite ein Abschnitt mit Thumbnail-Sektion mit den erforderlichen Eingaben bereitgestellt wird
+config_thumbnail_upload_mode_both#:#Beide Modi (Dateiupload und Zeitpunkt)
+config_thumbnail_upload_mode_both_info#:#Bei dieser Option werden beide Modi angeboten, die Benutzer müssen jedoch nur einen auswählen.
+config_thumbnail_upload_mode_file#:#Datei-Hochladen
+config_thumbnail_upload_mode_file_info#:#Mit dieser Option wird den Benutzern lediglich eine Dateieingabe zum Hochladen einer Vorschaubildsdatei bereitgestellt.
+config_thumbnail_upload_mode_timepoint#:#Zeitpunkt
+config_thumbnail_upload_mode_timepoint_info#:#Mit dieser Option wird den Benutzern nur eine Zeitauswahleingabe bereitgestellt, um den Zeitpunkt des Videos auszuwählen, von dem das Vorschaubild extrahiert werden soll.
+upload_ui_thumbnail_section#:#Vorschaubild
+upload_ui_thumbnail_mode_sg#:#Modus
+upload_ui_thumbnail_mode_sg_info#:#Sie können nur einen Modus zum Generieren von Vorschaubilder auswählen, indem Sie entweder eine Datei hochladen oder einen Zeitpunkt auswählen.
+upload_ui_thumbnail_mode_sg_file#:#Durch Hochladen einer Datei
+upload_ui_thumbnail_mode_sg_timepoint#:#Durch Auswahl eines Videozeitpunkts
+upload_ui_thumbnail_file#:#Vorschaubilddatei
+upload_ui_thumbnail_timepoint#:#Zeitpunkt
+upload_ui_thumbnail_timepoint_info#:#Der Zeitpunkt des Videos, aus dem das Vorschaubild extrahiert werden soll.

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -747,6 +747,8 @@ config_thumbnail_upload_mode_file_info#:#Mit dieser Option wird den Benutzern le
 config_thumbnail_upload_mode_timepoint#:#Zeitpunkt
 config_thumbnail_upload_mode_timepoint_info#:#Mit dieser Option wird den Benutzern nur eine Zeitauswahleingabe bereitgestellt, um den Zeitpunkt des Videos auszuwählen, von dem das Vorschaubild extrahiert werden soll.
 upload_ui_thumbnail_section#:#Vorschaubild
+upload_ui_thumbnail_section_stp_info#:#<strong>ACHTUNG:</strong> Damit diese Funktion funktioniert, müssen die "Straight to publishing" Verarbeitungseinstellung aktiviert sein.
+upload_ui_thumbnail_section_stp_disabled_info#:#<strong>ACHTUNG:</strong> Die "Straight to publishing" Verarbeitungseinstellung ist in den Konfigurationen deaktiviert, daher ist auch diese Funktion deaktiviert.
 upload_ui_thumbnail_mode_sg#:#Modus
 upload_ui_thumbnail_mode_sg_info#:#Sie können nur einen Modus zum Generieren von Vorschaubilder auswählen, indem Sie entweder eine Datei hochladen oder einen Zeitpunkt auswählen.
 upload_ui_thumbnail_mode_sg_file#:#Durch Hochladen einer Datei

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -736,3 +736,24 @@ config_paella_player_section_preview#:#Preview
 config_paella_player_section_caption#:#Caption
 config_paella_player_prevent_video_download#:#Prevent video download
 config_paella_player_prevent_video_download_info#:#When enabled, the direct video download from the player is prevented. <br> This can be achieved by right clicking on the video and select "save video as" or similar.
+subtab_thumbnails#:#Thumbnails
+config_thumbnail_upload_enabled#:#Enable thumbnail upload
+config_thumbnail_upload_enabled_info#:#Activating this option would enable uploading the thumbnail together with the video in the upload event form.<br><strong>NOTE:</strong> By default, "straightToPublishing" workflow parameter must be set to active, in order for this feature to work. This is because having "straightToPublishing" deactivated, puts the event in cutting mode, by which no thumbnail process is performed.
+config_thumbnail_accepted_mimetypes#:#Accepted File Types
+config_thumbnail_accepted_mimetypes_info#:#List of accepted extensions of the thumbnail file that users are allowed to upload.
+config_thumbnail_upload_mode#:#Upload Mode
+config_thumbnail_upload_mode_info#:#Selecting an option results in providing a thumbnail section in upload video page, with demanded input or inputs.
+config_thumbnail_upload_mode_both#:#Both modes (File upload and Timepoint)
+config_thumbnail_upload_mode_both_info#:#With this option, both modes are provided, but the users must select only one.
+config_thumbnail_upload_mode_file#:#File upload
+config_thumbnail_upload_mode_file_info#:#With this option, only a file input to upload thumbnail file is provided to the users.
+config_thumbnail_upload_mode_timepoint#:#Timepoint
+config_thumbnail_upload_mode_timepoint_info#:#With this option, only a timepicker input is provided to the users to select the timepoint of the video from whihc the thumbnail should be extracted.
+upload_ui_thumbnail_section#:#Thumbnail
+upload_ui_thumbnail_mode_sg#:#Mode
+upload_ui_thumbnail_mode_sg_info#:#You can select only one mode to generate thumbnails, either by uploading a file or selecting a timepoint.
+upload_ui_thumbnail_mode_sg_file#:#By uploading a file
+upload_ui_thumbnail_mode_sg_timepoint#:#By selecting a video tiempoint
+upload_ui_thumbnail_file#:#Thumbnail File
+upload_ui_thumbnail_timepoint#:#Timepoint
+upload_ui_thumbnail_timepoint_info#:#The time point of the video to extract thumbnail from.

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -750,6 +750,8 @@ config_thumbnail_upload_mode_file_info#:#With this option, only a file input to 
 config_thumbnail_upload_mode_timepoint#:#Timepoint
 config_thumbnail_upload_mode_timepoint_info#:#With this option, only a timepicker input is provided to the users to select the timepoint of the video from whihc the thumbnail should be extracted.
 upload_ui_thumbnail_section#:#Thumbnail
+upload_ui_thumbnail_section_stp_info#:#<strong>NOTE:</strong> "Straight to publishing" Processing setting must be enabled, in order for this feature to work.
+upload_ui_thumbnail_section_stp_disabled_info#:#<strong>NOTE:</strong> "Straight to publishing" Processing setting is disabled in the configurations, therefore this feature is disabled as well.
 upload_ui_thumbnail_mode_sg#:#Mode
 upload_ui_thumbnail_mode_sg_info#:#You can select only one mode to generate thumbnails, either by uploading a file or selecting a timepoint.
 upload_ui_thumbnail_mode_sg_file#:#By uploading a file

--- a/src/DI/OpencastDIC.php
+++ b/src/DI/OpencastDIC.php
@@ -45,6 +45,7 @@ use srag\Plugins\Opencast\Util\FileTransfer\PaellaConfigStorageService;
 use srag\Plugins\Opencast\Util\FileTransfer\UploadStorageService;
 use srag\Plugins\Opencast\Util\Player\PaellaConfigServiceFactory;
 use xoctFileUploadHandlerGUI;
+use srag\Plugins\Opencast\UI\ThumbnailConfig\ThumbnailConfigFormBuilder;
 
 /**
  * @deperecated use srag\Plugins\Opencast\Container\Container instead
@@ -315,6 +316,15 @@ class OpencastDIC
                 );
             }
         );
+        $this->container['thumbnail_config_form_builder'] = $this->container->factory(
+            function ($c): \srag\Plugins\Opencast\UI\ThumbnailConfig\ThumbnailConfigFormBuilder
+            {
+                return new ThumbnailConfigFormBuilder(
+                    $this->dic->ui()->factory(),
+                    $this->dic->ui()->renderer()
+                );
+            }
+        );
     }
 
     public function ingest_service(): OpencastIngestService
@@ -400,6 +410,11 @@ class OpencastDIC
     public function paella_config_form_builder(): PaellaConfigFormBuilder
     {
         return $this->container['paella_config_form_builder'];
+    }
+
+    public function thumbnail_config_form_builder() : ThumbnailConfigFormBuilder
+    {
+        return $this->container['thumbnail_config_form_builder'];
     }
 
     public function overwriteService(string $service_identifier, $value): void

--- a/src/Model/Config/PluginConfig.php
+++ b/src/Model/Config/PluginConfig.php
@@ -137,6 +137,11 @@ class PluginConfig extends ActiveRecord
     public const F_PAELLA_PREVIEW_FALLBACK = 'paella_config_preview_fallback';
     public const F_PAELLA_PREVIEW_FALLBACK_URL = 'paella_config_preview_fallback_url';
     public const PAELLA_DEFAULT_PREVIEW = 'Customizing/global/plugins/Services/Repository/RepositoryObject/OpenCast/templates/images/default_preview.png';
+
+    public const F_THUMBNAIL_UPLOAD_ENABLED = 'thumbnail_config_upload_enabled';
+    public const F_THUMBNAIL_UPLOAD_MODE = 'thumbnail_config_upload_mode';
+    public const F_THUMBNAIL_ACCEPTED_MIMETYPES = 'thumbnail_config_accepted_mimetypes';
+
     /**
      * @var array
      */

--- a/src/Model/Event/EventAPIRepository.php
+++ b/src/Model/Event/EventAPIRepository.php
@@ -105,7 +105,7 @@ class EventAPIRepository implements EventRepository, Request
      */
     public function upload(UploadEventRequest $request): void
     {
-        if (PluginConfig::getConfig(PluginConfig::F_INGEST_UPLOAD)) {
+        if (PluginConfig::getConfig(PluginConfig::F_INGEST_UPLOAD) || $request->getPayload()->hasThumbnail()) {
             $this->ingestService->ingest($request);
         } else {
             $payload = $request->getPayload()->jsonSerialize();

--- a/src/Model/Event/Request/UploadEventRequestPayload.php
+++ b/src/Model/Event/Request/UploadEventRequestPayload.php
@@ -28,17 +28,23 @@ class UploadEventRequestPayload
      * @var CURLFile
      */
     protected $presentation;
+    /**
+     * @var CURLFile
+     */
+    protected $thumbnail = null;
 
     public function __construct(
         Metadata $metadata,
         ACL $acl,
         Processing $processing,
-        xoctUploadFile $presentation
+        xoctUploadFile $presentation,
+        ?xoctUploadFile $thumbnail = null
     ) {
         $this->metadata = $metadata;
         $this->acl = $acl;
         $this->processing = $processing;
         $this->presentation = $presentation;
+        $this->thumbnail = $thumbnail;
     }
 
     public function getMetadata(): Metadata
@@ -59,6 +65,16 @@ class UploadEventRequestPayload
     public function getPresentation(): xoctUploadFile
     {
         return $this->presentation;
+    }
+
+    public function getThumbnail(): xoctUploadFile
+    {
+        return $this->thumbnail;
+    }
+
+    public function hasThumbnail(): bool
+    {
+        return !empty($this->thumbnail);
     }
 
     /**

--- a/src/UI/EventFormBuilder.php
+++ b/src/UI/EventFormBuilder.php
@@ -26,6 +26,7 @@ use ILIAS\UI\Implementation\Component\Input\Field\ChunkedFile;
 use srag\Plugins\Opencast\Model\Metadata\MetadataField;
 use srag\Plugins\Opencast\Model\Metadata\Definition\MDDataType;
 use DateTimeZone;
+use srag\Plugins\Opencast\DI\OpencastDIC;
 use ILIAS\UI\Component\Input\Field\Section;
 
 /**
@@ -38,6 +39,7 @@ class EventFormBuilder
     public const F_ACCEPT_EULA = 'accept_eula';
     public const MB_IN_B = 1000 * 1000;
     public const DEFAULT_UPLOAD_LIMIT_IN_MIB = 512;
+    public const F_THUMBNAIL_SECTION = 'thumbnail';
 
     private static $accepted_video_mimetypes = [
         MimeTypeUtil::VIDEO__AVI,
@@ -127,6 +129,10 @@ class EventFormBuilder
      * @var Container
      */
     private $dic;
+    /**
+     * @var OpencastDIC
+     */
+    private $opencast_dic;
 
     public function __construct(
         UIFactory $ui_factory,
@@ -150,6 +156,7 @@ class EventFormBuilder
         $this->schedulingFormItemBuilder = $schedulingFormItemBuilder;
         $this->seriesRepository = $seriesRepository;
         $this->dic = $dic;
+        $this->opencast_dic = OpencastDIC::getInstance();
     }
 
     /**
@@ -191,7 +198,11 @@ class EventFormBuilder
         // We must bind the WaitOverlay to an Input since the Form itself is not JS-bindable
         $file_input = $file_input->withAdditionalOnLoadCode(
             function ($id) {
-                return 'il.Opencast.UI.waitOverlay.onFormSubmit("#' . $id . '")';
+                $js = '
+                    il.Opencast.UI.waitOverlay.onFormSubmit("#' . $id . '");
+                    $("#' . $id . '").attr("data-videoFileInput", "' . $id . '");
+                ';
+                return $js;
             }
         );
 
@@ -210,6 +221,7 @@ class EventFormBuilder
                 $as_admin,
                 $this->plugin->txt('workflow_params_processing_settings')
             );
+
         $inputs = [
             'file' => $file_section,
             'metadata' => $this->formItemBuilder->create_section($as_admin),
@@ -217,6 +229,166 @@ class EventFormBuilder
         if (!is_null($workflow_param_section)) {
             $inputs['workflow_configuration'] = $workflow_param_section;
         }
+
+        // Thumbnails
+        $thumbnail_upload_enabled = PluginConfig::getConfig(PluginConfig::F_THUMBNAIL_UPLOAD_ENABLED) ?? false;
+        $accepted_thumbnail_mimetypes = PluginConfig::getConfig(PluginConfig::F_THUMBNAIL_ACCEPTED_MIMETYPES) ?? [];
+        $thumbnail_upload_mode = PluginConfig::getConfig(PluginConfig::F_THUMBNAIL_UPLOAD_MODE) ??
+            $this->opencast_dic->thumbnail_config_form_builder()::F_THUMBNAIL_UPLOAD_MODE_BOTH;
+        // Prepare the mode.
+        $thumbnail_upload_mode_is_both =
+            $thumbnail_upload_mode == $this->opencast_dic->thumbnail_config_form_builder()::F_THUMBNAIL_UPLOAD_MODE_BOTH;
+        $thumbnail_upload_mode_is_file =
+            $thumbnail_upload_mode == $this->opencast_dic->thumbnail_config_form_builder()::F_THUMBNAIL_UPLOAD_MODE_FILE;
+        $thumbnail_upload_mode_is_timepoint =
+            $thumbnail_upload_mode == $this->opencast_dic->thumbnail_config_form_builder()::F_THUMBNAIL_UPLOAD_MODE_TIMEPOINT;
+
+        if ($thumbnail_upload_enabled && !empty($accepted_thumbnail_mimetypes)) {
+            $thumbnail_section_inputs = [];
+            // Thumbnail file input.
+            $thumbnail_file_input = ChunkedFile::getInstance(
+                $this->uploadHandler,
+                $this->plugin->txt('upload_ui_thumbnail_file'),
+                $this->plugin->txt('event_supported_filetypes') . ': ' .
+                    implode(', ', array_values($accepted_thumbnail_mimetypes))
+            )->withRequired(false);
+
+            $thumbnail_file_input =
+                $thumbnail_file_input->withAcceptedMimeTypes(array_values($accepted_thumbnail_mimetypes))
+                ->withRequired(false)
+                // Only 1 file per one subtitle is allowed!
+                ->withMaxFiles(1)
+                ->withMaxFileSize($upload_limit)
+                // Setting ChunkSize as upload limit, in order to prevent unwanted chunking.
+                ->withChunkSizeInBytes($upload_limit)
+                ->withAdditionalTransformation(
+                    $this->refinery_factory->custom()->transformation(
+                        function ($file) use ($upload_storage_service): array {
+                            $id = $file[0] ?? '';
+                            return $upload_storage_service->getFileInfo($id);
+                        }
+                    )
+                );
+
+            // Thumbnail timepoint timepicker input.
+            $target_accept_video_files = implode(',',$this->getMimeTypes());
+            $date_default = new \DateTime('today midnight');
+            $value_format_str = $date_default->format('H:i:s');
+            $timepoint_picker = $factory->dateTime(
+                    $this->plugin->txt('upload_ui_thumbnail_timepoint'),
+                    $this->plugin->txt('upload_ui_thumbnail_timepoint_info')
+                )
+                ->withValue($value_format_str)
+                ->withTimeOnly(true)
+                ->withAdditionalOnLoadCode(function ($id) use ($target_accept_video_files) {
+                    $js = '
+                    // On show: Set min date, in order to prevent infinite loop.
+                    $("#' . $id . '").on("dp.show", function () {
+                        let minDate = new Date();
+                        minDate.setHours(0,0,0,0);
+                        $("#' . $id . '").data("DateTimePicker").minDate(minDate);
+                    });
+                    // On change: reset placeholder and the date value if clear is performed.
+                    $("#' . $id . '").on("dp.change", function ({date, oldDate}) {
+                        if (!date) {
+                            // Reset placeholder on clear.
+                            $("#' . $id . '").find("input").attr("placeholder", "00:00:00");
+                            // Reset value on clear.
+                            let resetDate = new Date();
+                            resetDate.setHours(0,0,0,0);
+                            $("#' . $id . '").data("DateTimePicker").date(resetDate);
+                        }
+                    });
+                    // Extra: set max duration based on uploaded video file.
+                    window.URL = window.URL || window.webkitURL;
+                    function bindEventExtractVideoDuration() {
+                        var file_inputs = $("input:file");
+                        if (file_inputs.length > 0) {
+                            file_inputs.each(function (i, el) {
+                                if ($(el).attr("accept") == "' . $target_accept_video_files . '") {
+                                    $(el).on("change" , function () {
+                                        let files = this.files;
+                                        let video = document.createElement("video");
+                                        video.preload = "metadata";
+                                        video.onloadedmetadata = function() {
+                                            const duration = video.duration;
+                                            const hours = parseInt(Math.floor(duration / 3600), 10);
+                                            const minutes = parseInt(Math.floor((duration % 3600) / 60), 10);
+                                            const remainingSeconds = parseInt(duration % 60, 10);
+                                            // Reset date.
+                                            const resetDate = new Date();
+                                            resetDate.setHours(0,0,0,0);
+                                            $("#' . $id . '").data("DateTimePicker").date(resetDate);
+                                            // Max date,
+                                            const maxDate = new Date();
+                                            maxDate.setHours(hours,minutes,remainingSeconds,0);
+                                            $("#' . $id . '").data("DateTimePicker").maxDate(maxDate);
+                                        }
+                                        video.src = URL.createObjectURL(files[0]);
+                                    });
+                                }
+                            });
+                        }
+                    }
+                    setTimeout(function () {
+                        bindEventExtractVideoDuration();
+                        $("[data-videoFileInput]").find(".ui-input-file-input-dropzone").on("drop", function () {
+                            bindEventExtractVideoDuration();
+                        });
+                        $("[data-videoFileInput]").find(".ui-input-file-input-dropzone > button").on("click", function () {
+                            bindEventExtractVideoDuration();
+                        });
+                    }, 500);';
+                    return $js;
+                })
+                ->withAdditionalPickerconfig([
+                    'useCurrent' => false,
+                    'format' => 'HH:mm:ss',
+                ]);
+
+            if ($thumbnail_upload_mode_is_both) {
+                $file_input_group = $factory->group(
+                    [
+                        "file" => $thumbnail_file_input
+                    ],
+                    $this->plugin->txt('upload_ui_thumbnail_mode_sg_file')
+                );
+                $timepoint_input_group = $factory->group(
+                    [
+                        "timepoint" => $timepoint_picker
+                    ],
+                    $this->plugin->txt('upload_ui_thumbnail_mode_sg_timepoint')
+                );
+
+                $switchable_group = $factory->switchableGroup(
+                    [
+                        'file' => $file_input_group,
+                        'timepoint' => $timepoint_input_group
+                    ],
+                    $this->plugin->txt('upload_ui_thumbnail_mode_sg'),
+                    $this->plugin->txt('upload_ui_thumbnail_mode_sg_info')
+                );
+                $thumbnail_section_inputs['mode'] = $switchable_group;
+            }
+            // Thumbnail File.
+            if ($thumbnail_upload_mode_is_file) {
+                $thumbnail_section_inputs['file'] = $thumbnail_file_input;
+            }
+
+            // Timepoint
+            if ($thumbnail_upload_mode_is_timepoint) {
+                $thumbnail_section_inputs['timepoint'] = $timepoint_picker;
+            }
+
+            if (!empty($thumbnail_section_inputs)) {
+                $thumbnail_section = $factory->section(
+                    $thumbnail_section_inputs,
+                    $this->plugin->txt('upload_ui_thumbnail_section'),
+                );
+                $inputs[self::F_THUMBNAIL_SECTION] = $thumbnail_section;
+            }
+        }
+
         if ($with_terms_of_use) {
             $inputs[self::F_ACCEPT_EULA] = $this->buildTermsOfUseSection();
         }

--- a/src/UI/Thumbnail/ThumbnailConfigFormBuilder.php
+++ b/src/UI/Thumbnail/ThumbnailConfigFormBuilder.php
@@ -1,0 +1,134 @@
+<?php
+
+declare(strict_types=1);
+
+namespace srag\Plugins\Opencast\UI\ThumbnailConfig;
+
+use ILIAS\UI\Component\Input\Container\Form\Standard;
+use srag\Plugins\Opencast\Model\Config\PluginConfig;
+use ILIAS\UI\Factory;
+use ILIAS\UI\Renderer;
+use srag\Plugins\Opencast\Util\Locale\LocaleTrait;
+use srag\Plugins\Opencast\Util\MimeType as MimeTypeUtil;
+
+/**
+ * Class ThumbnailConfigFormBuilder
+ *
+ * @author Farbod Zamani Boroujeni <zamani@elan-ev.de>
+ */
+class ThumbnailConfigFormBuilder
+{
+    use LocaleTrait;
+
+    public const F_THUMBNAIL_UPLOAD_ENABLED = 'thumbnail_upload_enabled';
+    public const F_THUMBNAIL_UPLOAD_MODE = 'thumbnail_upload_mode';
+    public const F_THUMBNAIL_UPLOAD_MODE_FILE = 'thumbnail_upload_mode_file';
+    public const F_THUMBNAIL_UPLOAD_MODE_TIMEPOINT = 'thumbnail_upload_mode_timepoint';
+    public const F_THUMBNAIL_UPLOAD_MODE_BOTH = 'thumbnail_upload_mode_both';
+    public const F_THUMBNAIL_ACCEPTED_MIMETYPES = 'thumbnail_accepted_mimetypes';
+    private static $accepted_thumbnail_extensions = [
+        MimeTypeUtil::IMAGE__JPEG => '.jpg',
+        MimeTypeUtil::IMAGE__PNG => '.png',
+    ];
+    /**
+     * @var ilPlugin
+     */
+    // private $plugin;
+    /**
+     * @var Factory
+     */
+    private $ui_factory;
+    /**
+     * @var Renderer
+     */
+    private $ui_renderer;
+
+    public function __construct(
+        Factory $ui_factory,
+        Renderer $ui_renderer
+    ) {
+        $this->ui_factory = $ui_factory;
+        $this->ui_renderer = $ui_renderer;
+    }
+
+    /**
+     * Builds the form.
+     *
+     * @param string $form_action the form action url     *
+     * @return Standard UI Componenet Standard form
+     */
+    public function buildForm(string $form_action): Standard
+    {
+        $dependant_fields = [];
+        // Accepted mimetypes.
+        $selected_types = (array) PluginConfig::getConfig(PluginConfig::F_THUMBNAIL_ACCEPTED_MIMETYPES) ??
+            [ MimeTypeUtil::IMAGE__JPEG ];
+        $dependant_fields[self::F_THUMBNAIL_ACCEPTED_MIMETYPES] = $this->ui_factory->input()->field()
+            ->multiselect(
+                $this->txt(self::F_THUMBNAIL_ACCEPTED_MIMETYPES),
+                self::$accepted_thumbnail_extensions,
+                $this->txt(self::F_THUMBNAIL_ACCEPTED_MIMETYPES . '_info')
+            )
+            ->withRequired(true)
+            ->withValue($selected_types);
+
+        // Modes.
+        $selected_mode = PluginConfig::getConfig(PluginConfig::F_THUMBNAIL_UPLOAD_MODE) ?? self::F_THUMBNAIL_UPLOAD_MODE_BOTH;
+        $dependant_fields[self::F_THUMBNAIL_UPLOAD_MODE] = $this->ui_factory->input()->field()
+            ->radio(
+                $this->txt(self::F_THUMBNAIL_UPLOAD_MODE),
+                $this->txt(self::F_THUMBNAIL_UPLOAD_MODE . '_info')
+            )
+            ->withOption(
+                self::F_THUMBNAIL_UPLOAD_MODE_BOTH,
+                $this->txt(self::F_THUMBNAIL_UPLOAD_MODE_BOTH),
+                $this->txt(self::F_THUMBNAIL_UPLOAD_MODE_BOTH  . '_info')
+            )
+            ->withOption(
+                self::F_THUMBNAIL_UPLOAD_MODE_TIMEPOINT,
+                $this->txt(self::F_THUMBNAIL_UPLOAD_MODE_TIMEPOINT),
+                $this->txt(self::F_THUMBNAIL_UPLOAD_MODE_TIMEPOINT  . '_info')
+            )
+            ->withOption(
+                self::F_THUMBNAIL_UPLOAD_MODE_FILE,
+                $this->txt(self::F_THUMBNAIL_UPLOAD_MODE_FILE),
+                $this->txt(self::F_THUMBNAIL_UPLOAD_MODE_FILE  . '_info')
+            )
+            ->withRequired(true)
+            ->withValue($selected_mode);
+
+        // Main enable upload thumbnail option.
+        $inputs = [];
+        $optional_group = $this->ui_factory->input()->field()->optionalGroup(
+            $dependant_fields,
+            $this->txt(
+                self::F_THUMBNAIL_UPLOAD_ENABLED
+            ),
+            $this->txt(
+                self::F_THUMBNAIL_UPLOAD_ENABLED . '_info'
+            ),
+        );
+
+        if (PluginConfig::getConfig(PluginConfig::F_THUMBNAIL_UPLOAD_ENABLED) == false) {
+            $optional_group = $optional_group->withValue(null);
+        }
+        $inputs[self::F_THUMBNAIL_UPLOAD_ENABLED] = $optional_group;
+
+        return $this->ui_factory->input()->container()->form()->standard(
+            $form_action,
+            $inputs
+        );
+    }
+
+    /**
+     * Gets the lang strings.
+     *
+     * @param string $string The lang string key
+     *
+     * @return string the lang string value
+     */
+    private function txt(string $string): string
+    {
+        return $this->getLocaleString($string, 'config');
+    }
+}

--- a/src/Util/FileTransfer/OpencastIngestService.php
+++ b/src/Util/FileTransfer/OpencastIngestService.php
@@ -53,6 +53,16 @@ class OpencastIngestService
             $this->uploadStorageService->buildACLUploadFile($payload->getAcl())->getFileStream()
         );
 
+        // If thumbnail exists, we add it into attachments
+        if ($payload->hasThumbnail()) {
+            $media_package = $this->api->routes()->ingest->addAttachment(
+                $media_package,
+                'presentation/preview', // NOTE: This is aligned with the workflow, change it if you use other flavors.
+                $payload->getThumbnail()->getFileStream(),
+                'player' // NOTE: This is aligned with the workflow, change it if you use other tags.
+            );
+        }
+
         // track
         $media_package = $this->api->routes()->ingest->addTrack(
             $media_package,
@@ -63,7 +73,9 @@ class OpencastIngestService
         // ingest
         $media_package = $this->api->routes()->ingest->ingest(
             $media_package,
-            $payload->getProcessing()->getWorkflow()
+            $payload->getProcessing()->getWorkflow(),
+            '',
+            (array) $payload->getProcessing()->getConfiguration()
         );
 
         // When we are done, we deactivate the ingest to keep everything clean.

--- a/vendor/composer/autoload_classmap.php
+++ b/vendor/composer/autoload_classmap.php
@@ -183,6 +183,7 @@ return array(
     'srag\\Plugins\\Opencast\\UI\\PaellaConfig\\PaellaConfigFormBuilder' => $baseDir . '/src/UI/PaellaConfig/PaellaConfigFormBuilder.php',
     'srag\\Plugins\\Opencast\\UI\\Scheduling\\SchedulingFormItemBuilder' => $baseDir . '/src/UI/Scheduling/SchedulingFormItemBuilder.php',
     'srag\\Plugins\\Opencast\\UI\\SeriesFormBuilder' => $baseDir . '/src/UI/SeriesFormBuilder.php',
+    'srag\\Plugins\\Opencast\\UI\\ThumbnailConfig\\ThumbnailConfigFormBuilder' => $baseDir . '/src/UI/Thumbnail/ThumbnailConfigFormBuilder.php',
     'srag\\Plugins\\Opencast\\Util\\FileTransfer\\OpencastIngestService' => $baseDir . '/src/Util/FileTransfer/OpencastIngestService.php',
     'srag\\Plugins\\Opencast\\Util\\FileTransfer\\PaellaConfigStorageService' => $baseDir . '/src/Util/FileTransfer/PaellaConfigStorageService.php',
     'srag\\Plugins\\Opencast\\Util\\FileTransfer\\UploadStorageService' => $baseDir . '/src/Util/FileTransfer/UploadStorageService.php',

--- a/vendor/composer/autoload_static.php
+++ b/vendor/composer/autoload_static.php
@@ -247,6 +247,7 @@ class ComposerStaticInit20975cba620fc47d8c392214bb856b0a
         'srag\\Plugins\\Opencast\\UI\\PaellaConfig\\PaellaConfigFormBuilder' => __DIR__ . '/../..' . '/src/UI/PaellaConfig/PaellaConfigFormBuilder.php',
         'srag\\Plugins\\Opencast\\UI\\Scheduling\\SchedulingFormItemBuilder' => __DIR__ . '/../..' . '/src/UI/Scheduling/SchedulingFormItemBuilder.php',
         'srag\\Plugins\\Opencast\\UI\\SeriesFormBuilder' => __DIR__ . '/../..' . '/src/UI/SeriesFormBuilder.php',
+        'srag\\Plugins\\Opencast\\UI\\ThumbnailConfig\\ThumbnailConfigFormBuilder' => __DIR__ . '/../..' . '/src/UI/Thumbnail/ThumbnailConfigFormBuilder.php',
         'srag\\Plugins\\Opencast\\Util\\FileTransfer\\OpencastIngestService' => __DIR__ . '/../..' . '/src/Util/FileTransfer/OpencastIngestService.php',
         'srag\\Plugins\\Opencast\\Util\\FileTransfer\\PaellaConfigStorageService' => __DIR__ . '/../..' . '/src/Util/FileTransfer/PaellaConfigStorageService.php',
         'srag\\Plugins\\Opencast\\Util\\FileTransfer\\UploadStorageService' => __DIR__ . '/../..' . '/src/Util/FileTransfer/UploadStorageService.php',


### PR DESCRIPTION
This PR fixes #291,

### Description
When uploading a video, user is now able to either upload a thumbnail file or select a timepoint in the video to extract thumbnail from.

### How it works
#### Configurations
- In Plugins configuration, there is now a new sub tab under Settings > Thumbnails
- In that config page:
   - admin should enable the thumbnail upload
   - admin needs to select the accepted file types for the thumbnail file to be uploaded
   - admin needs to select a mode to provide the possible ways of uploading thumbnail (either by timepoint or file upload)

#### Opencast Configuration
This feature depends on installing new workflows and encoding profiles in the Opencast System. Please use this document for more info: 

[Documentation_ Upload of thumbnail.pdf](https://github.com/user-attachments/files/15915449/Documentation_.Upload.of.thumbnail.pdf)

###### Encoding
- /etc/opencast/encoding/manual-thumb.properties

###### fast workflow (if in use)
- /etc/opencast/workflows/fast-with-thumbnail-support.xml 

###### schedule-and-upload workflow (if in use)
- /etc/opencast/workflows/schedule-and-upload-with-thumbnail-support.xml
- /etc/opencast/workflows/partial-publish-with-thumbnail-support.xml

#### Upload page
- There is a new section in upload page called "Thumbnail"
- depending on the admin selection for mode, users will see:
   - a switchable group of ui components if "Both modes" is selected, by which users can only select one way: either by uploading a file via File Input or selecting a timepoint via Timepicker.
   - Only a file input if "File Upload" is selected
   - Only a Timepicker input if the "Timepoint" is selected.
- The "straightToPublishing" workflow param value from the configuration is also reflected in this page, by providing related infos or disabling the section if the value is set to always inactive!

**NOTE:** As for uploading the file, we had to use ingest mechanism, therefore, you would need to make sure that the uplaod by ingest is configured in your Opencast!

### How to test:
- Opencast 15 and above.
- ILIAS 8
- Patch this PR.
- Configuring the thumbnails settings in plugin config. (Check different options and their outcomes)
- Upload video:
  - Upload thumbnail
  - Select a timepoint (the timepoint is smart, which means it gets the duration of the selected video and does not allow you to go beyond the duration by each you select a video)!
  - Both modes should also cover the above scenarios.

**NOTE:** Please help adjust or improve the German texts!