### PR TITLE
[Release 8] Scheduling Parser throws error on null inputs

### DIFF
--- a/src/Model/Scheduling/SchedulingParser.php
+++ b/src/Model/Scheduling/SchedulingParser.php
@@ -85,7 +85,7 @@ class SchedulingParser
             $data->agent_id,
             new DateTimeImmutable($data->start),
             new DateTimeImmutable($data->end),
-            $data->inputs,
+            $data->inputs ?? null,
             null,
             null
         );


### PR DESCRIPTION
Fix for #317 