### PR TITLE
[Release 8] Studio group

### DIFF
--- a/classes/Event/class.xoctEventGUI.php
+++ b/classes/Event/class.xoctEventGUI.php
@@ -890,7 +890,16 @@ class xoctEventGUI extends xoctGUI
             $this->main_tpl->setOnScreenMessage('failure', $this->txt('msg_no_access'), true);
             $this->cancel();
         }
-        $this->addCurrentUserToProducers();
+        // Consider studio group as default.
+        $user_group_name = PluginConfig::F_GROUP_STUDIO;
+
+        // Looking for "Edit Video" permission, to add user to producers group.
+        if (ilObjOpenCastAccess::hasPermission(ilObjOpenCastAccess::PERMISSION_EDIT_VIDEOS)) {
+            $user_group_name = PluginConfig::F_GROUP_PRODUCERS;
+        }
+
+        $this->addCurrentUserToGroup($user_group_name);
+
         // redirect to oc studio
         $base = rtrim(PluginConfig::getConfig(PluginConfig::F_API_BASE), "/");
         $base = str_replace('/api', '', $base);
@@ -924,7 +933,7 @@ class xoctEventGUI extends xoctGUI
             $this->cancel();
         }
 
-        $this->addCurrentUserToProducers();
+        $this->addCurrentUserToGroup();
 
         // redirect
         $cutting_link = $event->publications()->getCuttingLink();
@@ -1016,7 +1025,7 @@ class xoctEventGUI extends xoctGUI
 
         // check access
         if (ilObjOpenCastAccess::hasPermission(ilObjOpenCastAccess::PERMISSION_EDIT_VIDEOS) || ilObjOpenCastAccess::hasWriteAccess()) {
-            $this->addCurrentUserToProducers();
+            $this->addCurrentUserToGroup();
         }
 
         // redirect
@@ -1427,30 +1436,41 @@ class xoctEventGUI extends xoctGUI
         return $intro_text;
     }
 
-    protected function addCurrentUserToProducers(): void
+    /**
+     * Adds the current user to the specified group.
+     * Producers group is the default selected group. (PluginConfig::F_GROUP_PRODUCERS)
+     *
+     * @param string $group_config_name the group config name (default PluginConfig::F_GROUP_PRODUCERS)
+     *
+     */
+    protected function addCurrentUserToGroup(string $group_config_name = PluginConfig::F_GROUP_PRODUCERS): void
     {
         $xoctUser = xoctUser::getInstance($this->user);
-        // add user to ilias producers
+        // add user to the group
         $sleep = false;
         try {
-            if ($group_producers = PluginConfig::getConfig(PluginConfig::F_GROUP_PRODUCERS)) {
-                $ilias_producers = Group::find($group_producers);
-                $sleep = $ilias_producers->addMember($xoctUser);
+            $group_config_value = PluginConfig::getConfig($group_config_name);
+            if (!empty($group_config_value)) {
+                $group_obj = Group::find($group_config_value);
+                $sleep = $group_obj->addMember($xoctUser);
             }
         } catch (xoctException $e) {
         }
 
-        // add user to series producers
-        if ($this->objectSettings->getSeriesIdentifier() !== null) {
-            $series = $this->seriesRepository->find($this->objectSettings->getSeriesIdentifier());
-            if ($series->getAccessPolicies()->merge($this->ACLUtils->getUserRolesACL($xoctUser))) {
-                $this->seriesRepository->updateACL(
-                    new UpdateSeriesACLRequest(
-                        $series->getIdentifier(),
-                        new UpdateSeriesACLRequestPayload($series->getAccessPolicies())
-                    )
-                );
-                $sleep = true;
+        // Extra things to do for producers group.
+        if ($group_config_name === PluginConfig::F_GROUP_PRODUCERS) {
+            // add user to series producers
+            if ($this->objectSettings->getSeriesIdentifier() !== null) {
+                $series = $this->seriesRepository->find($this->objectSettings->getSeriesIdentifier());
+                if ($series->getAccessPolicies()->merge($this->ACLUtils->getUserRolesACL($xoctUser))) {
+                    $this->seriesRepository->updateACL(
+                        new UpdateSeriesACLRequest(
+                            $series->getIdentifier(),
+                            new UpdateSeriesACLRequestPayload($series->getAccessPolicies())
+                        )
+                    );
+                    $sleep = true;
+                }
             }
         }
 

--- a/configuration/default_config.xml
+++ b/configuration/default_config.xml
@@ -71,6 +71,10 @@
       <value><![CDATA[ROLE_GROUP_ILIAS]]></value>
     </xoct_conf>
     <xoct_conf>
+      <name>group_studio</name>
+      <value><![CDATA[ROLE_GROUP_STUDIO]]></value>
+    </xoct_conf>
+    <xoct_conf>
       <name>identifier_to_uppercase</name>
       <value><![CDATA[1]]></value>
     </xoct_conf>

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -100,6 +100,9 @@ config_sign_thumbnail_links_time_info#:#Wie lange der Link für Thumbnail gülti
 config_sign_thumbnail_links_with_ip#:#Für Client-IP signieren
 config_groups#:#Opencast-Gruppen
 config_group_producers#:#ILIAS Producers
+config_group_producers_info#:#Benutzer mit dem Recht "Videos editieren" werden vom Plugin in der hier angegebenen Opencast-Gruppe eingeschrieben, um dadurch Zugriff auf Opencast zu erhalten.
+config_group_studio#:#Opencast Studio
+config_group_studio_info#:#Benutzer mit dem Recht "Aufzeichen" werden vom Plugin in der hier angegebenen Opencast-Gruppe eingeschrieben, um dadurch Zugriff auf Opencast Studio zu erhalten.
 config_std_roles#:#Standardrollen
 config_std_roles_info#:#Die hier angegebenen Rollen erhalten Schreib- und Leserechte beim Erstellen eines Events oder einer Serie.
 config_role_user_actions#:#Zusätzliche ACL Aktionen
@@ -115,7 +118,6 @@ config_use_modals_info#:#Wenn aktiviert: Beim Abspielen von Videos wird kein neu
 config_workflow_info#:#ID des Workflows, welcher nach dem Hochladen eines Videos in Opencast angewendet wird.
 config_workflow_unpublish_info#:#ID des Workflows, welcher vor dem Löschen eines Videos in Opencast angewendet wird. Benötigt API-Version 1.1.0. Wird bei neueren Opencast-Versionen nicht mehr benötigt, da im Löschvorgang integriert.
 config_user_mapping_info#:#Benutzerfeld in ILIAS, welches zur Identifikation eines Benutzers in Opencast verwendet werden soll. <br><b>Achtung: Die E-Mail-Adresse kann je nach ILIAS-Konfiguration durch den Benutzer selbst geändert werden. In diesem Fall sollte die E-Mail-Adresse auf keinen Fall als Mapping verwendet werden.</b>
-config_group_producers_info#:#Benutzer mit dem Recht "Videos editieren" werden vom Plugin in der hier angegebenen Opencast-Gruppe eingeschrieben, um dadurch Zugriff auf Opencast zu erhalten.
 config_role_user_prefix_info#:#Benutzereigene Rolle in Opencast. Wird auf Serien gesetzt, um dem Benutzer genügend Rechte in Opencast einzuräumen. Bsp: ROLE_USER_&#123IDENTIFIER}
 config_role_owner_prefix_info#:#Gibt den Besitzer eines Events an. Diese Rolle muss NICHT in Opencast existieren. Bsp: ROLE_OWNER_&#123IDENTIFIER}. NICHT den gleichen Wert wie für Benutzerrolle wählen.
 config_identifier_to_uppercase#:#User-Mapping in Großbuchstaben

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -103,6 +103,9 @@ config_reset_terms#:#Updated Terms of Use
 config_reset_terms_info#:#Request users to (re-)accept the terms of use. This option should only be activated if the term's content has changed.
 config_groups#:#Opencast Groups
 config_group_producers#:#ILIAS Producers
+config_group_producers_info#:#Users with the permission "Edit Videos" will be assigned to this Opencast group to obtain access to Opencast.
+config_group_studio#:#Opencast Studio
+config_group_studio_info#:#Users with the permission "Record" will be assigned to this Opencast group to obtain access to Opencast Studio.
 config_std_roles#:#Standard roles
 config_std_roles_info#:#These roles are given read and write permissions when creating a series or an event.
 config_role_user_actions#:#Additional ACL actions
@@ -119,7 +122,6 @@ config_use_modals_info#:#When active: the video player will not be opened in a s
 config_workflow_info#:#ID of the workflow which will be executed in Opencast after uploading an event.
 config_workflow_unpublish_info#:#ID of the workflow which will be executed in Opencast before deleting an event. Requires API version 1.1.0. Not required in latest Opencast versions, since it's integrated in the delete workflow.
 config_user_mapping_info#:#Userfield in ILIAS which will be used to identify the user in Opencast.<br><b>Warning: depending on the ILIAS configuration, users may be able to change their own email address. It is strongly recommended not to use email as mapping in that case.</b>
-config_group_producers_info#:#Users with the permission "Edit Videos" will be assigned to this Opencast group to obtain access to Opencast.
 config_role_user_prefix_info#:#User specific role in Opencast. Is used to grant the user permission on a series in Opencast. Example: ROLE_USER_&#123IDENTIFIER}
 config_role_owner_prefix_info#:#Indicates the owner of an event. This rules doesn't have to exist in Opencast. Example: ROLE_OWNER_&#123IDENTIFIER}. DO NOT use the same value as for the user specific role.
 config_identifier_to_uppercase#:#User mapping in uppercase

--- a/src/Model/Config/PluginConfig.php
+++ b/src/Model/Config/PluginConfig.php
@@ -158,7 +158,7 @@ class PluginConfig extends ActiveRecord
     /**
      * @var array
      */
-    public static $groups = [
+    public static array $groups = [
         self::F_GROUP_PRODUCERS,
         self::F_GROUP_STUDIO,
     ];

--- a/src/Model/Config/PluginConfig.php
+++ b/src/Model/Config/PluginConfig.php
@@ -50,6 +50,7 @@ class PluginConfig extends ActiveRecord
     public const CACHE_DATABASE = 2;
     public const F_USER_MAPPING = 'user_mapping';
     public const F_GROUP_PRODUCERS = 'group_producers';
+    public const F_GROUP_STUDIO = 'group_studio';
     public const F_STD_ROLES = 'std_roles';
     public const F_ROLE_USER_PREFIX = 'role_user_prefix';
     public const F_ROLE_USER_ACTIONS = 'role_user_actions';
@@ -159,6 +160,7 @@ class PluginConfig extends ActiveRecord
      */
     public static $groups = [
         self::F_GROUP_PRODUCERS,
+        self::F_GROUP_STUDIO,
     ];
 
     /**


### PR DESCRIPTION
This PR fixes #339

### What is new
- A new group configuration right below ILIAS Producers is introduced named "Opencast Studio"
- The `addCurrentUserToProducer` method is now optimized to support different groups and it is renamed to `addCurrentUserToGroup`
- Clicking on Opencast Studio, system will add users to producers group if they have Edit Video perm, otherwise, they will be added to studio group!

This PR might get updated...