### PR TITLE
[FIX] wrong translation of scheduled events

### DIFF
--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -252,7 +252,7 @@ event_state_not_published#:#Nicht publiziert, für Studierende noch nicht sichtb
 event_state_ready_for_cutting#:#Nicht publiziert (Schnitt erforderlich), für Studierende noch nicht sichtbar.
 event_state_running#:#Wird konvertiert, für Studierende noch nicht sichtbar.
 event_state_offline#:#Offline, für Studierende nicht sichtbar.
-event_state_scheduled#:#Aufzeichnung wird verarbeitet, für Studierende nicht sichtbar.
+event_state_scheduled#:#Geplante Aufzeichnung, für Studierende nicht sichtbar.
 event_state_scheduled_offline#:#Aufzeichnung wird verarbeitet (Offline), für Studierende nicht sichtbar.
 event_state_recording#:#Wird momentan Aufgezeichnet, für Studierende nicht sichtbar.
 event_state_live_scheduled#:#Live-Übertragung (noch nicht begonnen). Offen ab %s.

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -252,7 +252,7 @@ event_state_not_published#:#Not published, not yet visible to students
 event_state_ready_for_cutting#:#Not published (ready for cutting), not yet visible to students
 event_state_running#:#Converting, not yet visible to students
 event_state_offline#:#Offline, not visible to students
-event_state_scheduled#:#Preprocessing ongoing, not visible to students.
+event_state_scheduled#:#Scheduled event, not visible to students.
 event_state_scheduled_offline#:#Preprocessing ongoing (Offline), not visible to students.
 event_state_recording#:#Is currently being recorded, not visible to students.
 event_state_live_scheduled#:#Live Stream (not started yet). Open from %s.


### PR DESCRIPTION
This is the fix for #342, @dagraf could you please have a look at this? The plugin languages must be reloaded to apply this fix.