### PR TITLE
[Release 8] fix broken ACL xml and startDate xml metadata when using ingest upload

### DIFF
--- a/classes/Request/class.xoctUploadFile.php
+++ b/classes/Request/class.xoctUploadFile.php
@@ -129,10 +129,14 @@ class xoctUploadFile
     }
 
     /**
-     * @return resource filestream
+     * @return resource|null filestream
      */
     public function getFileStream()
     {
-        return fopen($this->getPath(), 'rb');
+        $file_stream = null;
+        if (file_exists($this->getPath())) {
+            $file_stream = fopen($this->getPath(), 'rb');
+        }
+        return $file_stream;
     }
 }

--- a/src/Util/FileTransfer/OpencastIngestService.php
+++ b/src/Util/FileTransfer/OpencastIngestService.php
@@ -11,6 +11,7 @@ use srag\Plugins\Opencast\API\API;
 use ilFFmpeg;
 use ilShellUtil;
 use srag\Plugins\Opencast\Container\Init;
+use SimpleXMLElement;
 
 class OpencastIngestService
 {
@@ -39,6 +40,13 @@ class OpencastIngestService
         // create media package
         $media_package = $this->api->routes()->ingest->createMediaPackage();
 
+        // Try to extract media package id.
+        $media_package_id = 'mediapackage-1';
+        if (!empty($media_package)) {
+            $media_package_xml = new SimpleXMLElement($media_package);
+            $media_package_id = (string) $media_package_xml['id'];
+        }
+
         // Metadata
         $media_package = $this->api->routes()->ingest->addDCCatalog(
             $media_package,
@@ -50,7 +58,7 @@ class OpencastIngestService
         $media_package = $this->api->routes()->ingest->addAttachment(
             $media_package,
             'security/xacml+episode',
-            $this->uploadStorageService->buildACLUploadFile($payload->getAcl())->getFileStream()
+            $this->uploadStorageService->buildACLUploadFile($payload->getAcl(), $media_package_id)->getFileStream()
         );
 
         // Subtitles using addTrack ingest method.

--- a/src/Util/FileTransfer/UploadStorageService.php
+++ b/src/Util/FileTransfer/UploadStorageService.php
@@ -16,6 +16,7 @@ use srag\Plugins\Opencast\Model\ACL\ACL;
 use srag\Plugins\Opencast\Util\Transformator\ACLtoXML;
 use xoctUploadFile;
 use ILIAS\Filesystem\DTO\Metadata;
+use srag\Plugins\Opencast\Util\MimeType as MimeTypeUtil;
 
 class UploadStorageService
 {
@@ -128,12 +129,13 @@ class UploadStorageService
 
     public function buildACLUploadFile(ACL $acl, string $media_package_id): xoctUploadFile
     {
-        $tmp_name = uniqid('tmp', false);
+        $tmp_name = uniqid('tmp', false) . '.xml';
         $this->fileSystem->write($this->idToDirPath($tmp_name), (new ACLtoXML($acl))->getXML($media_package_id));
         $upload_file = new xoctUploadFile();
         $upload_file->setFileSize(
             $this->fileSystem->getSize($this->idToDirPath($tmp_name), DataSize::Byte)->getSize()
         );
+        $upload_file->setMimeType(MimeTypeUtil::APPLICATION__XML);
         $upload_file->setPostVar('attachment');
         $upload_file->setTitle('attachment');
         $upload_file->setPath(ILIAS_DATA_DIR . '/' . CLIENT_ID . '/temp/' . $this->idToDirPath($tmp_name));

--- a/src/Util/FileTransfer/UploadStorageService.php
+++ b/src/Util/FileTransfer/UploadStorageService.php
@@ -126,14 +126,13 @@ class UploadStorageService
         ];
     }
 
-    public function buildACLUploadFile(ACL $acl): xoctUploadFile
+    public function buildACLUploadFile(ACL $acl, string $media_package_id): xoctUploadFile
     {
         $tmp_name = uniqid('tmp', false);
-        $this->fileSystem->write($this->idToDirPath($tmp_name), (new ACLtoXML($acl))->getXML());
+        $this->fileSystem->write($this->idToDirPath($tmp_name), (new ACLtoXML($acl))->getXML($media_package_id));
         $upload_file = new xoctUploadFile();
         $upload_file->setFileSize(
-            $this->fileSystem->getSize($this->idToDirPath($tmp_name), DataSize::Byte)
-                             ->getSize()
+            $this->fileSystem->getSize($this->idToDirPath($tmp_name), DataSize::Byte)->getSize()
         );
         $upload_file->setPostVar('attachment');
         $upload_file->setTitle('attachment');

--- a/src/Util/Transformator/ACLtoXML.php
+++ b/src/Util/Transformator/ACLtoXML.php
@@ -49,7 +49,7 @@ class ACLtoXML
         $xml_writer->xmlElement('AttributeValue', [
             'DataType' => 'http://www.w3.org/2001/XMLSchema#string'
         ], $media_package_id);
-        $xml_writer->xmlElement('ActionAttributeDesignator', [
+        $xml_writer->xmlElement('ResourceAttributeDesignator', [
             'AttributeId' => 'urn:oasis:names:tc:xacml:1.0:resource:resource-id',
             'DataType' => 'http://www.w3.org/2001/XMLSchema#string'
         ]);

--- a/src/Util/Transformator/ACLtoXML.php
+++ b/src/Util/Transformator/ACLtoXML.php
@@ -38,6 +38,27 @@ class ACLtoXML
             'xmlns' => 'urn:oasis:names:tc:xacml:2.0:policy:schema:os'
         ]);
 
+        // Add Resource id as target tag.
+        $xml_writer->xmlStartTag('Target');
+        $xml_writer->xmlStartTag('Resources');
+        $xml_writer->xmlStartTag('Resource');
+        $xml_writer->xmlStartTag('ResourceMatch', [
+            'MatchId' => 'urn:oasis:names:tc:xacml:1.0:function:string-equal'
+        ]);
+
+        $xml_writer->xmlElement('AttributeValue', [
+            'DataType' => 'http://www.w3.org/2001/XMLSchema#string'
+        ], $media_package_id);
+        $xml_writer->xmlElement('ActionAttributeDesignator', [
+            'AttributeId' => 'urn:oasis:names:tc:xacml:1.0:resource:resource-id',
+            'DataType' => 'http://www.w3.org/2001/XMLSchema#string'
+        ]);
+
+        $xml_writer->xmlEndTag('ResourceMatch');
+        $xml_writer->xmlEndTag('Resource');
+        $xml_writer->xmlEndTag('Resources');
+        $xml_writer->xmlEndTag('Target');
+
         foreach ($this->acl->getEntries() as $acl) {
             if ($acl->isAllow()) {
                 $xml_writer->xmlStartTag('Rule', [

--- a/src/Util/Transformator/ACLtoXML.php
+++ b/src/Util/Transformator/ACLtoXML.php
@@ -26,12 +26,13 @@ class ACLtoXML
         $this->acl = $acl;
     }
 
-    public function getXML(): string
+    public function getXML(string $media_package_id = 'mediapackage-1'): string
     {
         $xml_writer = new ilXMLWriter();
+        $xml_writer->xmlSetGenCmt("Opencast ILIAS Plugin Access Policy Generator");
         $xml_writer->xmlHeader();
         $xml_writer->xmlStartTag('Policy', [
-            'PolicyId' => 'mediapackage-1',
+            'PolicyId' => $media_package_id,
             'RuleCombiningAlgId' => 'urn:oasis:names:tc:xacml:1.0:rule-combining-algorithm:permit-overrides',
             'Version' => '2.0',
             'xmlns' => 'urn:oasis:names:tc:xacml:2.0:policy:schema:os'
@@ -40,7 +41,7 @@ class ACLtoXML
         foreach ($this->acl->getEntries() as $acl) {
             if ($acl->isAllow()) {
                 $xml_writer->xmlStartTag('Rule', [
-                    'RuleId' => 'user_' . $acl->getAction() . '_permit',
+                    'RuleId' => $acl->getRole() . '_' . $acl->getAction() . '_permit',
                     'Effect' => 'Permit'
                 ]);
 
@@ -83,6 +84,12 @@ class ACLtoXML
                 $xml_writer->xmlEndTag('Rule');
             }
         }
+
+        // Deny rule.
+        $xml_writer->xmlElement('Rule', [
+            'RuleId' => 'DenyRule',
+            'Effect' => 'Deny'
+        ]);
 
         $xml_writer->xmlEndTag('Policy');
 

--- a/src/Util/Transformator/MetadataToXML.php
+++ b/src/Util/Transformator/MetadataToXML.php
@@ -57,7 +57,7 @@ class MetadataToXML
             ),
             IL_CAL_UNIX
         )
-        )->get(IL_CAL_FKT_DATE, 'Y-m-d\TH:i:s.u\Z');
+        )->get(IL_CAL_FKT_DATE, 'Y-m-d\TH:i:s.u\Z', 'GMT');
         $xml_writer->xmlElement('dcterms:temporal', [
             'xsi:type' => 'dcterms:Period'
         ], 'start=' . $start_end_string_iso . '; ' . 'end=' . $start_end_string_iso . '; scheme=W3C-DTF;');
@@ -66,7 +66,7 @@ class MetadataToXML
             'dcterms:created',
             [],
             (new ilDateTime(time(), IL_CAL_UNIX))
-                ->get(IL_CAL_FKT_DATE, 'Y-m-d\TH:i:s.u\Z', 'UTC')
+                ->get(IL_CAL_FKT_DATE, 'Y-m-d\TH:i:s.u\Z', 'GMT')
         );
 
         $xml_writer->xmlEndTag('dublincore');


### PR DESCRIPTION
This PR
fixes #350
fixes #349

## Problem:
When using Ingest to upload videos:
- startDate metadata is shown +2h
- ACLs are broken and faulty

## Solution
- startDate => has to have GMT as its timezone
- ACLs XML generator now has all the missing tags and incompelete tag id and resources.
