### PR TITLE
[Release 8] controlling chat visibility: only when event is/was live!

### DIFF
--- a/classes/Player/class.xoctPlayerGUI.php
+++ b/classes/Player/class.xoctPlayerGUI.php
@@ -37,18 +37,12 @@ class xoctPlayerGUI extends xoctGUI
     public const ROLE_MASTER = "presenter";
     public const ROLE_SLAVE = "presentation";
     private bool $force_no_chat;
-    /**
-     * @var string|null
-     */
-    private $identifier;
-    protected ObjectSettings $object_settings;
-    protected PublicationUsageRepository $publication_usage_repository;
+    private ?string $identifier;
+    private ObjectSettings $object_settings;
+    private PublicationUsageRepository $publication_usage_repository;
     private EventRepository $event_repository;
     private PaellaConfigService $paellaConfigService;
-    /**
-     * @var \ilObjUser
-     */
-    private $user;
+    private \ilObjUser $user;
 
     public function __construct(
         EventRepository $event_repository,
@@ -73,7 +67,7 @@ class xoctPlayerGUI extends xoctGUI
      */
     public function streamVideo(): void
     {
-        if (!isset($this->identifier) || empty($this->identifier)) {
+        if (empty($this->identifier)) {
             $this->sendReponse("Error: invalid identifier");
         }
         $event = $this->event_repository->find($this->identifier);
@@ -117,12 +111,11 @@ class xoctPlayerGUI extends xoctGUI
 
         if ($this->isChatVisible()) {
             $this->initChat($event, $tpl);
-        } else {
-            $tpl->setVariable(
-                "STYLE_SHEET_LOCATION",
-                $this->plugin->getDirectory() . "/templates/default/player.css"
-            );
         }
+        $tpl->setVariable(
+            "STYLE_SHEET_LOCATION",
+            $this->plugin->getDirectory() . "/templates/default/player.css"
+        );
 
         setcookie('lastProfile', '', ['expires' => -1]);
         $this->sendReponse($tpl->get());

--- a/classes/Player/class.xoctPlayerGUI.php
+++ b/classes/Player/class.xoctPlayerGUI.php
@@ -158,12 +158,23 @@ class xoctPlayerGUI extends xoctGUI
         return $js_config;
     }
 
+    /**
+     * Function to check whether the chat must be provided to the user based on the following conditions:
+     * - Event must be identified as Live
+     * - The "Live Streams" config must be activated.
+     * - The "Activate Chat" config must be activated.
+     * - The "Chat for live events" in series object settings must be activated.
+     *
+     * @param Event $event the event object to check whether the event is live or not.
+     * @return boolean whether the chat should be visible.
+     */
     protected function isChatVisible(Event $event): bool
     {
         return !$this->force_no_chat
             && $event->isLiveEvent() // The event must only be live to provide the chat!
-            && PluginConfig::getConfig(PluginConfig::F_ENABLE_CHAT)
-            && $this->object_settings->isChatActive();
+            && PluginConfig::getConfig(PluginConfig::F_ENABLE_LIVE_STREAMS) // The Live Streams config must be activated.
+            && PluginConfig::getConfig(PluginConfig::F_ENABLE_CHAT) // The Chat config must be activated.
+            && $this->object_settings->isChatActive(); // The series object settings must allow the chat.
     }
 
     /**

--- a/src/Chat/GUI/ChatHistoryGUI.php
+++ b/src/Chat/GUI/ChatHistoryGUI.php
@@ -44,13 +44,19 @@ class ChatHistoryGUI
         foreach (
             MessageAR::where(['chat_room_id' => $this->chat_room_id])->orderBy('sent_at', 'ASC')->get() as $message
         ) {
+            if (!$message->getUsrId()) {
+                continue;
+            }
             $template->setCurrentBlock('message');
             /** @var $message MessageAR */
             $template->setVariable('USER_ID', $message->getUsrId());
             $template->setVariable('MESSAGE', $message->getMessage());
-            $user = $users[$message->getUsrId()] ?: ($users[$message->getUsrId()] = new ilObjUser(
-                $message->getUsrId()
-            ));
+            if (!empty($users) && array_key_exists($message->getUsrId(), $users)) {
+                $user = $users[$message->getUsrId()];
+            } else {
+                $user = new ilObjUser($message->getUsrId());
+                $users[$message->getUsrId()] = $user;
+            }
             $template->setVariable('PUBLIC_NAME', $user->hasPublicProfile() ? $user->getFullname() : $user->getLogin());
             $template->setVariable('SENT_AT', date('H:i', strtotime($message->getSentAt())));
             $profile_picture_path = './data/' . CLIENT_ID . '/usr_images/usr_' . $message->getUsrId() . '_xsmall.jpg';

--- a/src/Chat/node/public/css/chat.css
+++ b/src/Chat/node/public/css/chat.css
@@ -11,7 +11,11 @@ html {
     overflow: hidden;
 }
 
-#srchat_iframe_container {
+#srchat_history_container {
+    overflow: hidden !important;
+}
+
+#srchat_iframe_container, #srchat_history_container {
     border-left: 3px solid #aeaeae;
 }
 
@@ -20,7 +24,7 @@ html {
     height: 100%;
 }
 
-#srchat_body {
+#srchat_body, #srchat_history_container {
     display: flex;
     flex-direction: column;
     font: 16px Helvetica, Arial;
@@ -252,7 +256,7 @@ span.srchat_pseudo_element {
         transform: rotate(-180deg);
     }
 
-    #srchat_iframe_container {
+    #srchat_iframe_container, #srchat_history_container {
         border-top: 3px solid #aeaeae;
         border-left: none;
     }
@@ -281,7 +285,7 @@ span.srchat_pseudo_element {
 
 
 @media screen and (max-device-width: 768px) and (orientation: landscape) {
-    #srchat_iframe_container {
+    #srchat_iframe_container, #srchat_history_container {
         display: none;
     }
 }

--- a/templates/default/Chat/history.html
+++ b/templates/default/Chat/history.html
@@ -1,4 +1,7 @@
-<div id="srchat_container">
+<div id="srchat_history_container">
+    <div id="srchat_title">
+        <h4>Chat</h4>
+    </div>
     <div id="chat_body">
         <ul id="messages">
             <!-- BEGIN message -->


### PR DESCRIPTION
This is the complementary fix for #348
It fixes #346
it also fixes #333

## Reason
- There were uncontrolled and messy checker for live events and subsequently providing chat resources for live events in wrong scenrios!

## Solution
- `isChatVisible` now has an specific checker where it checks if the event is live (can be running or scheduled), otherwise regular `player.css` will be loaded!
- `initChat` now has provide the chat precisely:
    - when the live event is running => just provide an empty clean chat
    - when the live event is not yet running => just provide the history (this part of the code is almost dead, and I would see any usecase for it or at least it is super outdated!)
    - the above mentioned checkers are based on what I could understand from the old code! feel free to discuss this if you know more about `ChatHistoryGUI`: chat history ...
    
#### NOTE: It is very important to test this for the following 3 scenarios and see the chat behavior:
1. for normal video (on-demand playbacks) => no chat
<del>2. for live events **but not yet started** => (enabled? => chat history) (disabled? => no chat)</del>
2. When a live event (with chats and messages in that chat room) is ended, and the video is already processed by the oc and is now a on-demand video, then the chat has to be displayed as well added in: https://github.com/opencast-ilias/OpenCast/pull/354/commits/f1cafd2b036f7c2ac249f871d6144ed55d86228e
3. for live **running** events => (enabled? => new clean chat) (disabled? => no chat)

#### [UPDATE]: Since the PR also includes the fix for #333, there should be another scenario to test:
- The chat visibility also depends on the general "Live Streams" plugin config with higher priority, that means if that config is deactivated (no matter if other conditions are met) the chat will never be shown!