### PR TITLE
Sorting, Fix 341

### DIFF
--- a/classes/Event/class.xoctEventTableGUI.php
+++ b/classes/Event/class.xoctEventTableGUI.php
@@ -208,7 +208,7 @@ class xoctEventTableGUI extends ilTable2GUI
             $field_id = $md_field->getFieldId();
             $columns[$field_id] = [
                 'selectable' => true,
-                'sort_field' => $field_id . '_s',
+                'sort_field' => $field_id,
                 'text' => $md_field->getTitle($this->lang_key)
             ];
         }


### PR DESCRIPTION
See #341 , Sorting issue.

Sorting failed due to attempting sorting on an array, since raw data instead of object data was set as sort field for meta data. 

Note, why do we even keep the raw data for the table, it seems that we aways use the data from the stored object.

Further note that the issue can be nasty, since users can not open channels anymore if sorted on the wrong field.