### PR TITLE
[FIX] introduce "title" as mandatory MD for series

### DIFF
--- a/classes/Conf/Metadata/class.xoctMetadataConfigGUI.php
+++ b/classes/Conf/Metadata/class.xoctMetadataConfigGUI.php
@@ -17,7 +17,6 @@ use srag\Plugins\Opencast\Model\Metadata\Definition\MDDataType;
 use srag\Plugins\Opencast\Model\ListProvider\ListProvider;
 use srag\Plugins\Opencast\LegacyHelpers\TranslatorTrait;
 use srag\Plugins\Opencast\Util\Locale\LocaleTrait;
-use ILIAS\DI\HTTPServices;
 use ILIAS\DI\UIServices;
 
 abstract class xoctMetadataConfigGUI extends xoctGUI
@@ -54,7 +53,7 @@ abstract class xoctMetadataConfigGUI extends xoctGUI
     protected MDCatalogueFactory $md_catalogue_factory;
     protected Container $dic;
     private ilToolbarGUI $toolbar;
-    private UIServices  $ui;
+    private UIServices $ui;
     private ListProvider $listprovider;
     private array $post_ids = [];
 
@@ -76,7 +75,6 @@ abstract class xoctMetadataConfigGUI extends xoctGUI
         $this->post_ids = $this->http->request()->getParsedBody()['ids'] ?? [];
     }
 
-
     public function executeCommand(): void
     {
         $cmd = $this->ctrl->getCmd(self::CMD_STANDARD);
@@ -85,7 +83,6 @@ abstract class xoctMetadataConfigGUI extends xoctGUI
         }
         $this->$cmd();
     }
-
 
     protected function index(): void
     {
@@ -113,6 +110,7 @@ abstract class xoctMetadataConfigGUI extends xoctGUI
     {
         return new MDConfigTable(
             $this,
+            $this->getMetadataCatalogue(),
             $this->getTableTitle(),
             $this->dic,
             $this->plugin,
@@ -194,15 +192,21 @@ abstract class xoctMetadataConfigGUI extends xoctGUI
                 $digested_list = $this->digestList($this->listprovider->getList($source), $field_id);
                 if (!empty($digested_list)) {
                     $separator = MDFieldConfigAR::VALUE_SEPERATOR;
-                    $converted_list = array_map(function ($key, $value) use ($separator) {
-                        return "$key$separator$value";
-                    }, array_keys($digested_list), array_values($digested_list));
+                    $converted_list = array_map(fn ($key, $value): string => "$key$separator$value", array_keys($digested_list), array_values($digested_list));
                     if (!empty($converted_list)) {
                         $encoded_list = base64_encode(json_encode($converted_list));
                         $this->ctrl->setParameter($this, 'possible_values_list', $encoded_list);
-                        $this->main_tpl->setOnScreenMessage('success', $this->plugin->txt('msg_md_listproviders_load_success'), true);
+                        $this->main_tpl->setOnScreenMessage(
+                            'success',
+                            $this->plugin->txt('msg_md_listproviders_load_success'),
+                            true
+                        );
                     } else {
-                        $this->main_tpl->setOnScreenMessage('failure', $this->plugin->txt('msg_md_listproviders_load_invalid'), true);
+                        $this->main_tpl->setOnScreenMessage(
+                            'failure',
+                            $this->plugin->txt('msg_md_listproviders_load_invalid'),
+                            true
+                        );
                     }
                 }
             } else {
@@ -222,7 +226,7 @@ abstract class xoctMetadataConfigGUI extends xoctGUI
     /**
      * Converts or better say digest the loaded list and replaces the translation to be processed by the plugin.
      *
-     * @param array  $raw_list the raw list that comes from the listprovider endpoints
+     * @param array $raw_list  the raw list that comes from the listprovider endpoints
      * @param string $field_id the field id to differentiate between the list type
      *
      * @return array of digested list.
@@ -231,7 +235,7 @@ abstract class xoctMetadataConfigGUI extends xoctGUI
     {
         $digested = [];
         foreach ($raw_list as $key => $value) {
-            if ($field_id == 'language') {
+            if ($field_id === 'language') {
                 $split = explode('.', $value);
                 $default_text = ucfirst(strtolower($split[count($split) - 1]));
                 $translated = $this->getLocaleString(
@@ -242,7 +246,7 @@ abstract class xoctMetadataConfigGUI extends xoctGUI
                 $digested[$key] = $translated;
                 continue;
             }
-            if ($field_id == 'license') {
+            if ($field_id === 'license') {
                 $value = json_decode($value);
                 if (!$value) {
                     continue;
@@ -287,23 +291,25 @@ abstract class xoctMetadataConfigGUI extends xoctGUI
     protected function delete(): void
     {
         $field_id = $this->dic->http()->request()->getQueryParams()['field_id'];
+
+        $definition = $this->getMetadataCatalogue()->getFieldById($field_id);
+        if ($definition->isMandatory()) {
+            $this->main_tpl->setOnScreenMessage('failure', $this->plugin->txt('msg_md_delete_mandatory'), true);
+            $this->ctrl->redirect($this, self::CMD_STANDARD);
+        }
+
         $this->repository->delete($field_id);
         $this->dic->ctrl()->redirect($this, self::CMD_STANDARD);
     }
 
     protected function getAvailableMetadataFields(): array
     {
-        $already_configured = array_map(function (MDFieldConfigAR $md_config): string {
-            return $md_config->getFieldId();
-        }, $this->repository->getAll(false));
-        $available_total = array_map(function (MDFieldDefinition $md_field_def): string {
-            return $md_field_def->getId();
-        }, $this->getMetadataCatalogue()->getFieldDefinitions());
+        $already_configured = array_map(fn (MDFieldConfigAR $md_config): string => $md_config->getFieldId(), $this->repository->getAll(false));
+        $available_total = array_map(fn (MDFieldDefinition $md_field_def): string => $md_field_def->getId(), $this->getMetadataCatalogue()->getFieldDefinitions());
         return array_diff($available_total, $already_configured);
     }
 
     abstract protected function getMetadataCatalogue(): MDCatalogue;
-
 
     protected function buildForm(string $field_id): Standard
     {
@@ -322,7 +328,7 @@ abstract class xoctMetadataConfigGUI extends xoctGUI
             )
                                            ->withRequired(true)
                                            ->withValue(
-                                               $md_field_config instanceof \srag\Plugins\Opencast\Model\Metadata\Config\MDFieldConfigAR ? $md_field_config->getTitle(
+                                               $md_field_config instanceof MDFieldConfigAR ? $md_field_config->getTitle(
                                                    'de'
                                                ) : ''
                                            ),
@@ -331,7 +337,7 @@ abstract class xoctMetadataConfigGUI extends xoctGUI
             )
                                            ->withRequired(true)
                                            ->withValue(
-                                               $md_field_config instanceof \srag\Plugins\Opencast\Model\Metadata\Config\MDFieldConfigAR ? $md_field_config->getTitle(
+                                               $md_field_config instanceof MDFieldConfigAR ? $md_field_config->getTitle(
                                                    'en'
                                                ) : ''
                                            ),
@@ -343,7 +349,7 @@ abstract class xoctMetadataConfigGUI extends xoctGUI
                 ]
             )->withRequired(true)
                                                           ->withValue(
-                                                              $md_field_config instanceof \srag\Plugins\Opencast\Model\Metadata\Config\MDFieldConfigAR ? $md_field_config->getVisibleForPermissions(
+                                                              $md_field_config instanceof MDFieldConfigAR ? $md_field_config->getVisibleForPermissions(
                                                               ) : null
                                                           ),
             'required' => $this->ui_factory->input()->field()->checkbox(
@@ -450,7 +456,7 @@ abstract class xoctMetadataConfigGUI extends xoctGUI
                 'fields' => $this->ui_factory->input()->field()->section(
                     $fields,
                     $this->plugin->txt(
-                        'md_conf_form_' . ($md_field_config instanceof \srag\Plugins\Opencast\Model\Metadata\Config\MDFieldConfigAR ? 'edit' : 'create')
+                        'md_conf_form_' . ($md_field_config instanceof MDFieldConfigAR ? 'edit' : 'create')
                     )
                 )
             ]

--- a/classes/Conf/Metadata/class.xoctMetadataConfigGUI.php
+++ b/classes/Conf/Metadata/class.xoctMetadataConfigGUI.php
@@ -226,7 +226,7 @@ abstract class xoctMetadataConfigGUI extends xoctGUI
     /**
      * Converts or better say digest the loaded list and replaces the translation to be processed by the plugin.
      *
-     * @param array $raw_list  the raw list that comes from the listprovider endpoints
+     * @param array $raw_list the raw list that comes from the listprovider endpoints
      * @param string $field_id the field id to differentiate between the list type
      *
      * @return array of digested list.

--- a/classes/Setup/class.ilOpenCastDBUpdateSteps.php
+++ b/classes/Setup/class.ilOpenCastDBUpdateSteps.php
@@ -55,4 +55,31 @@ class ilOpenCastDBUpdateSteps implements \ilDatabaseUpdateSteps
         }
         $this->db->renameTableColumn($table_name, $old_column_name, $new_column_name);
     }
+
+    public function step_3(): void
+    {
+        // check for missing mandatory "title" MD for series
+        $r = $this->db->query("SELECT id FROM xoct_md_field_series WHERE field_id = 'title'");
+        if ($r->rowCount() > 0) {
+            return;
+        }
+
+        $next_id = $this->db->nextId('xoct_md_field_series');
+
+        $this->db->insert(
+            'xoct_md_field_series',
+            [
+                'id' => ['integer', $next_id],
+                'field_id' => ['text', 'title'],
+                'title_de' => ['text', 'Titel'],
+                'title_en' => ['text', 'Ttitle'],
+                'visible_for_permissions' => ['text', 'all'],
+                'required' => ['integer', 1],
+                'read_only' => ['integer', 0],
+                'prefill' => ['text', ''],
+                'sort' => ['integer', 1],
+                'values' => ['text', '']
+            ]
+        );
+    }
 }

--- a/classes/Setup/class.ilOpenCastDBUpdateSteps.php
+++ b/classes/Setup/class.ilOpenCastDBUpdateSteps.php
@@ -82,4 +82,31 @@ class ilOpenCastDBUpdateSteps implements \ilDatabaseUpdateSteps
             ]
         );
     }
+
+    public function step_4(): void
+    {
+        // check for missing mandatory "title" MD for series
+        $r = $this->db->query("SELECT id FROM xoct_md_field_event WHERE field_id = 'title'");
+        if ($r->rowCount() > 0) {
+            return;
+        }
+
+        $next_id = $this->db->nextId('xoct_md_field_event');
+
+        $this->db->insert(
+            'xoct_md_field_event',
+            [
+                'id' => ['integer', $next_id],
+                'field_id' => ['text', 'title'],
+                'title_de' => ['text', 'Titel'],
+                'title_en' => ['text', 'Title'],
+                'visible_for_permissions' => ['text', 'all'],
+                'required' => ['integer', 1],
+                'read_only' => ['integer', 0],
+                'prefill' => ['text', ''],
+                'sort' => ['integer', 1],
+                'values' => ['text', '']
+            ]
+        );
+    }
 }

--- a/classes/Setup/class.ilOpenCastDBUpdateSteps.php
+++ b/classes/Setup/class.ilOpenCastDBUpdateSteps.php
@@ -85,7 +85,7 @@ class ilOpenCastDBUpdateSteps implements \ilDatabaseUpdateSteps
 
     public function step_4(): void
     {
-        // check for missing mandatory "title" MD for series
+        // check for missing mandatory "title" MD for event
         $r = $this->db->query("SELECT id FROM xoct_md_field_event WHERE field_id = 'title'");
         if ($r->rowCount() > 0) {
             return;

--- a/classes/Setup/class.ilOpenCastDBUpdateSteps.php
+++ b/classes/Setup/class.ilOpenCastDBUpdateSteps.php
@@ -72,7 +72,7 @@ class ilOpenCastDBUpdateSteps implements \ilDatabaseUpdateSteps
                 'id' => ['integer', $next_id],
                 'field_id' => ['text', 'title'],
                 'title_de' => ['text', 'Titel'],
-                'title_en' => ['text', 'Ttitle'],
+                'title_en' => ['text', 'Title'],
                 'visible_for_permissions' => ['text', 'all'],
                 'required' => ['integer', 1],
                 'read_only' => ['integer', 0],

--- a/classes/class.ilObjOpenCast.php
+++ b/classes/class.ilObjOpenCast.php
@@ -1,8 +1,6 @@
 <?php
 
 declare(strict_types=1);
-
-use srag\Plugins\Opencast\DI\OpencastDIC;
 use srag\Plugins\Opencast\Model\Config\PluginConfig;
 use srag\Plugins\Opencast\Model\Metadata\Definition\MDFieldDefinition;
 use srag\Plugins\Opencast\Model\Metadata\Metadata;
@@ -32,7 +30,7 @@ class ilObjOpenCast extends ilObjectPlugin
     /**
      * @param int $a_ref_id
      */
-    public function __construct($a_ref_id = 0)
+    public function __construct(int $a_ref_id = 0)
     {
         global $DIC;
         $this->ctrl = $DIC->ctrl();
@@ -58,9 +56,17 @@ class ilObjOpenCast extends ilObjectPlugin
 
         $title = $metadata->getField(MDFieldDefinition::F_TITLE)->getValue();
         $description = $metadata->getField(MDFieldDefinition::F_DESCRIPTION)->getValue();
-        if ($title != $this->getTitle() || $description != $this->getDescription()) {
+        $update = false;
+        if ($title !== $this->getTitle()) {
             $this->setTitle($title);
+            $update = true;
+        }
+
+        if ($description !== $this->getDescription()) {
             $this->setDescription($description);
+            $update = true;
+        }
+        if ($update) {
             $this->update();
         }
     }
@@ -153,7 +159,7 @@ class ilObjOpenCast extends ilObjectPlugin
         }
 
         $course_or_group = null;
-        if ($ref_id) {
+        if ($ref_id !== 0) {
             /** @var ilObjCourse|ilObjGroup $course_or_group */
             $course_or_group = ilObjectFactory::getInstanceByRefId($ref_id);
             $crs_or_grp_cache[$ref_id] = $course_or_group;

--- a/src/Model/Metadata/Definition/MDCatalogueFactory.php
+++ b/src/Model/Metadata/Definition/MDCatalogueFactory.php
@@ -16,7 +16,7 @@ class MDCatalogueFactory
     public function event(): MDCatalogue
     {
         return $this->event_catalogue ?? $this->event_catalogue = new MDCatalogue([
-            new MDFieldDefinition(MDFieldDefinition::F_TITLE, MDDataType::text(), false, true),
+            new MDFieldDefinition(MDFieldDefinition::F_TITLE, MDDataType::text(), false, true, true), // Title is Mandatory for Events
             new MDFieldDefinition(MDFieldDefinition::F_SUBJECTS, MDDataType::text_array(), false, false),
             new MDFieldDefinition(MDFieldDefinition::F_DESCRIPTION, MDDataType::text_long(), false, false),
             new MDFieldDefinition(MDFieldDefinition::F_RIGHTS_HOLDER, MDDataType::text(), false, false),

--- a/src/Model/Metadata/Definition/MDCatalogueFactory.php
+++ b/src/Model/Metadata/Definition/MDCatalogueFactory.php
@@ -38,7 +38,7 @@ class MDCatalogueFactory
     public function series(): MDCatalogue
     {
         return $this->series_catalogue ?? $this->series_catalogue = new MDCatalogue([
-            new MDFieldDefinition(MDFieldDefinition::F_TITLE, MDDataType::text(), false, true),
+            new MDFieldDefinition(MDFieldDefinition::F_TITLE, MDDataType::text(), false, true, true), // Title is Mandatory for Series
             new MDFieldDefinition(MDFieldDefinition::F_DESCRIPTION, MDDataType::text_long(), false, false),
             new MDFieldDefinition(MDFieldDefinition::F_RIGHTS_HOLDER, MDDataType::text(), false, false),
             new MDFieldDefinition(MDFieldDefinition::F_CREATED_BY, MDDataType::text(), true, false),

--- a/src/Model/Metadata/Definition/MDFieldDefinition.php
+++ b/src/Model/Metadata/Definition/MDFieldDefinition.php
@@ -29,13 +29,20 @@ class MDFieldDefinition
     private MDDataType $type;
     private bool $read_only;
     private bool $required;
+    private bool $mandatory;
 
-    public function __construct(string $id, MDDataType $type, bool $read_only, bool $required)
-    {
+    public function __construct(
+        string $id,
+        MDDataType $type,
+        bool $read_only,
+        bool $required,
+        bool $mandatory = false
+    ) {
         $this->id = $id;
         $this->type = $type;
         $this->read_only = $read_only;
         $this->required = $required;
+        $this->mandatory = $mandatory;
     }
 
     public function getId(): string
@@ -56,5 +63,10 @@ class MDFieldDefinition
     public function isRequired(): bool
     {
         return $this->required;
+    }
+
+    public function isMandatory(): bool
+    {
+        return $this->mandatory;
     }
 }

--- a/src/Model/Metadata/Helper/MDParser.php
+++ b/src/Model/Metadata/Helper/MDParser.php
@@ -181,6 +181,7 @@ class MDParser
             default:
                 return $value;
         }
+        return null;
     }
 
     /**
@@ -203,17 +204,14 @@ class MDParser
     private function parseFormData(array $data, Metadata $metadata, MDCatalogue $catalogue): Metadata
     {
         foreach (
-            array_filter($data, function ($key): bool {
-                return strpos($key, 'md_') === 0;
-            }, ARRAY_FILTER_USE_KEY)
-            as $id => $value
+            array_filter($data, fn ($key): bool => strpos($key, 'md_') === 0, ARRAY_FILTER_USE_KEY) as $id => $value
         ) {
             $id = substr($id, 3);
             $definition = $catalogue->getFieldById($id);
             if ($definition->isReadOnly()) {
                 continue;
             }
-            if ($id == MDFieldDefinition::F_START_DATE) {
+            if ($id === MDFieldDefinition::F_START_DATE) {
                 // start date must be split up into startDate and startTime for the OC api
                 $field = new MetadataField($id, MDDataType::date());
                 $time_field = (new MetadataField(MDFieldDefinition::F_START_TIME, MDDataType::time()));


### PR DESCRIPTION
This PR should fix the issue in #328 

Currently it's possible to delete or never configure the metadata field "title" for series. This leads to errors on both sides, ILIAS and even opencast.

The fix introduces an update step which creates the missing field if it doesn't exist. beside that, the MD definition now holds a "mandatory" flag und the delete action is no longer available for mandatory fields.