### PR TITLE
[fix] #374 response from OC-16 changed

### DIFF
--- a/src/Util/Player/LivePlayerDataBuilder.php
+++ b/src/Util/Player/LivePlayerDataBuilder.php
@@ -26,7 +26,11 @@ class LivePlayerDataBuilder extends PlayerDataBuilder
             OpencastAPI::RETURN_ARRAY
         );
 
-        $media_package = $episode_data['search-results']['result']['mediapackage'];
+        if(array_key_exists('search-results', $episode_data)) {
+            $media_package = $episode_data['search-results']['result']['mediapackage'];
+        } else {
+            $media_package = $episode_data['result'][0]['mediapackage'];
+        }
 
         $source_format = PluginConfig::getConfig(PluginConfig::F_LIVESTREAM_BUFFERED) ? 'hls' : 'hlsLive';
         $streams = [];

--- a/src/Util/Player/LivePlayerDataBuilder.php
+++ b/src/Util/Player/LivePlayerDataBuilder.php
@@ -26,7 +26,9 @@ class LivePlayerDataBuilder extends PlayerDataBuilder
             OpencastAPI::RETURN_ARRAY
         );
 
-        if(array_key_exists('search-results', $episode_data)) {
+        //Temporary fix until this issue is fixed in the opencast-php-library:
+        //https://github.com/elan-ev/opencast-php-library/issues/33
+        if (array_key_exists('search-results', $episode_data)) {
             $media_package = $episode_data['search-results']['result']['mediapackage'];
         } else {
             $media_package = $episode_data['result'][0]['mediapackage'];


### PR DESCRIPTION
This PR fixes this issue #374.
The responce from the OpenCast Version 16 API has changed from the response with OC-Version 15. 
The changes can also be seen in the docu: https://docs.opencast.org/r/16.x/admin/upgrade/#api-changes

There is no 'search-results' being returned in OC16. So i check if that arraykey 'search-results' exists to determine if the version is older than 16.