### PR TITLE
fixes #384: remove parameter not needed

### DIFF
--- a/src/Container/Init.php
+++ b/src/Container/Init.php
@@ -122,10 +122,7 @@ final class Init
                 $activated
             );
 
-            return new Services(
-                $config,
-                $opencast_container[\ILIAS\DI\Container::class]->database()
-            );
+            return new Services($config);
         });
 
         $opencast_container->glue(EventAPIRepository::class, fn(): EventAPIRepository => new EventAPIRepository(

--- a/src/Model/Cache/Services.php
+++ b/src/Model/Cache/Services.php
@@ -44,7 +44,7 @@ class Services
     private Factory $adaptor_factory;
     private Config $config;
 
-    public function __construct(Config $config, \ilDBInterface $db)
+    public function __construct(Config $config)
     {
         $this->config = $config;
         $this->adaptor_factory = new Factory();


### PR DESCRIPTION
In order to fix the issue #384 I removed the db-parameter from the constructor in the service class. 
The db is not neeed in the constructor of the service class. 
I also did not find another line in the code where that constructor was used.
This solved the error: Call to a member function database() on null 