### PR TITLE
[FIX] partial fix for issue 386, prevent copy items in manage view of course

### DIFF
--- a/classes/class.ilObjOpenCastAccess.php
+++ b/classes/class.ilObjOpenCastAccess.php
@@ -110,32 +110,28 @@ class ilObjOpenCastAccess extends ilObjectPluginAccess
     ];
 
 
-    /**
-     * @param string $a_cmd
-     * @param string $a_permission
-     * @param int    $a_ref_id
-     * @param int    $a_obj_id
-     * @param string $a_user_id
-     */
-    public function _checkAccess($a_cmd, $a_permission, $a_ref_id, $a_obj_id = null, $a_user_id = ''): bool
+
+    public function _checkAccess(string $cmd, string $permission, int $ref_id, int $obj_id, ?int $user_id = null): bool
     {
-        if (empty($a_user_id)) {
-            $a_user_id = $this->user->getId();
+        if ($user_id === null) {
+            $user_id = $this->user->getId();
         }
-        if ($a_obj_id === null) {
-            $a_obj_id = ilObject2::_lookupObjId($a_ref_id);
+        if ($obj_id === 0) {
+            $obj_id = ilObject2::_lookupObjId($ref_id);
         }
 
-        $a_obj_id = (int) $a_obj_id;
+        $obj_id = (int) $obj_id;
 
-        switch ($a_permission) {
+        switch ($permission) {
+            case 'copy':
+                return false;
             case 'read':
             case 'visible':
-                if (!ilObjOpenCastAccess::checkOnline($a_obj_id) && !$this->access->checkAccessOfUser(
-                    $a_user_id,
+                if (!self::checkOnline($obj_id) && !$this->access->checkAccessOfUser(
+                    $user_id,
                     'write',
                     '',
-                    $a_ref_id
+                    $ref_id
                 )) {
                     return false;
                 }

--- a/classes/class.ilObjOpenCastAccess.php
+++ b/classes/class.ilObjOpenCastAccess.php
@@ -110,7 +110,9 @@ class ilObjOpenCastAccess extends ilObjectPluginAccess
     ];
 
 
-
+    /**
+     * @inheritDoc
+     */
     public function _checkAccess(string $cmd, string $permission, int $ref_id, int $obj_id, ?int $user_id = null): bool
     {
         if ($user_id === null) {

--- a/classes/trait.ilObjShowDuplicates.php
+++ b/classes/trait.ilObjShowDuplicates.php
@@ -15,7 +15,6 @@ use srag\Plugins\Opencast\Model\Object\ObjectSettings;
  */
 trait ilObjShowDuplicates
 {
-
     private $items_to_delete = [];
 
     /**
@@ -139,9 +138,9 @@ trait ilObjShowDuplicates
                     $path .= $data['title'];
                 } else {
                     $path .= ('<a target="_top" href="' . ilLink::_getLink(
-                            (int) $data['ref_id'],
-                            $data['type']
-                        ) . '">' . $data['title'] . '</a>');
+                        (int) $data['ref_id'],
+                        $data['type']
+                    ) . '">' . $data['title'] . '</a>');
                 }
             }
 
@@ -162,10 +161,9 @@ trait ilObjShowDuplicates
         $il_access_handler = $this->ilias_dic->access();
 
         // process
-
         /** @var ObjectSettings $objectSettings */
         $objectSettings = ObjectSettings::find($a_obj_id);
-        if ($all_refs = $objectSettings->getDuplicatesOnSystem()) {
+        if ($objectSettings && $all_refs = $objectSettings->getDuplicatesOnSystem()) {
             $il_language->loadLanguageModule("rep");
 
             $may_delete_any = 0;
@@ -197,7 +195,8 @@ trait ilObjShowDuplicates
             // render
             $tpl = new ilTemplate(
                 "./Customizing/global/plugins/Services/Repository/RepositoryObject/OpenCast/templates/default/tpl.rep_multi_ref.html",
-                true, true
+                true,
+                true
             );
 
             $tpl->setVariable("TXT_INTRO", $il_language->txt("rep_multiple_reference_deletion_intro"));

--- a/classes/trait.ilObjShowDuplicates.php
+++ b/classes/trait.ilObjShowDuplicates.php
@@ -163,7 +163,8 @@ trait ilObjShowDuplicates
         // process
         /** @var ObjectSettings $objectSettings */
         $objectSettings = ObjectSettings::find($a_obj_id);
-        if ($objectSettings && $all_refs = $objectSettings->getDuplicatesOnSystem()) {
+        $all_refs = $objectSettings ?  $objectSettings->getDuplicatesOnSystem() : null;
+        if (!empty($all_refs)) {
             $il_language->loadLanguageModule("rep");
 
             $may_delete_any = 0;


### PR DESCRIPTION
This PR prevents copying objects in manage view of courses. The plugin itself already "defines" that copy should not be possible. ILIAS seems to ignore that, I tried to track this down in ILIAS Core but just found a lot of old code and was not able to find the right place where this should be checked in ILIAS. This PR provides a workaround: while checking permissions, the plugin now always returns `false` for the copy-permission. this at least prevents from generating (non-functions) copies of Opencast objects in ILIAS.