### PR TITLE
[Release_8] Opencast Studio link enhancements: hidden Series + ACLs

### DIFF
--- a/src/Util/Transformator/ACLtoXML.php
+++ b/src/Util/Transformator/ACLtoXML.php
@@ -116,4 +116,32 @@ class ACLtoXML
 
         return $xml_writer->xmlDumpMem(false);
     }
+
+    /**
+     * Generates a JSON representation of the ACL entries for use in the Opencast Studio Link as upload.acl.
+     *
+     * The JSON format is a nested object where the keys are role names and the values are arrays of actions.
+     * Only entries with an "allow" permission are included.
+     *
+     * @return string The JSON representation of the ACL entries consumable for the Opencast Studio.
+     */
+    public function getStudioACLObjectNotation(): string
+    {
+        $acl_notation_array = [];
+        foreach ($this->acl->getEntries() as $entry) {
+            $role = $entry->getRole();
+            $action = $entry->getAction();
+            $allow = $entry->isAllow();
+            if ($allow) {
+                if (!isset($acl_notation_array[$role])) {
+                    $acl_notation_array[$role] = [];
+                }
+                if (!in_array($action, $acl_notation_array[$role])) {
+                    $acl_notation_array[$role][] = $action;
+                }
+            }
+        }
+        $acl_notation_string = !empty($acl_notation_array) ? json_encode($acl_notation_array) : '';
+        return $acl_notation_string;
+    }
 }


### PR DESCRIPTION
This PR fixes #382

### Description
It has been requested to make it possible to pass the User ACLs also to Studio, as well as hiding the series id field in the studio!
Please refer to https://github.com/opencast-ilias/OpenCast/issues/382#issue-2730298527 for more info!

### Solution
- Make the query param prepration a bit more cleaner by using arrays etc.
- Add seriesField=hidden into the query params of Studio Link
- Add a new function: `ACLtoXML->getStudioACLObjectNotation` which is responsible to convert the acl entries into an acl notation object string consumable by Studio via [elan-ev/opencast-studio #1212](https://github.com/elan-ev/opencast-studio/pull/1212)
- Pass that ACL notation object string as "upload.acl" param to the query params string

### To TEST
You would need to:
- Patch this PR
- Patch [elan-ev/opencast-studio #1212](https://github.com/elan-ev/opencast-studio/pull/1212)
- Adjust your Roles in `Plugin Config > Settings > Groups & Roles`
- Make sure Studio is configured!
- Go to a series repo object in a course with a user that has Studio Upload Right
- Click on the Opencast Studio button
- Make sure to upload any video in studio and validate the changes:
   - The series ID has to be "hidden" in the Studio UI upload form.
   - After the video is upload the ACLs must be presented to the Access policy list of that event as it would come from a normal video upload from ILIAS Plugin!