### PR TITLE
[release_9]: Get Chat activation default value from config

### DIFF
--- a/src/Model/Object/ObjectSettingsParser.php
+++ b/src/Model/Object/ObjectSettingsParser.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace srag\Plugins\Opencast\Model\Object;
 
+use srag\Plugins\Opencast\Model\Config\PluginConfig;
 use srag\Plugins\Opencast\UI\ObjectSettings\ObjectSettingsFormItemBuilder;
 
 class ObjectSettingsParser
@@ -25,7 +26,13 @@ class ObjectSettingsParser
             is_array($data[ObjectSettingsFormItemBuilder::F_PERMISSION_PER_CLIP] ?? null)
             && $data[ObjectSettingsFormItemBuilder::F_PERMISSION_PER_CLIP][ObjectSettingsFormItemBuilder::F_PERMISSION_ALLOW_SET_OWN] ?? false
         );
-        $objectSettings->setChatActive((bool) ($data[ObjectSettingsFormItemBuilder::F_CHAT_ACTIVE] ?? false));
+        // Taking the default value from configs!
+        $chat_activation = (bool) PluginConfig::getConfig(PluginConfig::F_ENABLE_CHAT);
+        // If the data contains the chat activation, we will use that value instead of the default one.
+        if (isset($data[ObjectSettingsFormItemBuilder::F_CHAT_ACTIVE])) {
+            $chat_activation = (bool) $data[ObjectSettingsFormItemBuilder::F_CHAT_ACTIVE];
+        }
+        $objectSettings->setChatActive($chat_activation);
 
         return $objectSettings;
     }


### PR DESCRIPTION
This PR fixes #400,

### Description
When the config "Activate Chat" is activated, the default for the setting "Chat for live events" that is now shown in the setting of series should be "Activated" by default when creating new series!

### How it works
By creating a new series the default value of the "Activate Chat" config will be set as the default value for the series setting.
On the other hand it also forces the setting to be disabled when the whole "Activate Chat" config is disabled.

### To test
- Make sure to patch this PR
- In Opencast Plugin Config under `Settings > Event > LiveStream` make sure "Activate Chat" config option is checked
- Save changes
- Go to a course and create a new series
- After the series is created, go to the series settings => the "Chat for live events" option must be enabled by default!
- Try to disable that settings option "Chat for live events" and save changes. => the option must be saved successfully and work as expected!
- Now try to disable the "Activate Chat" config in the plugin configs (2. step), save changes.
- Try to create a new series object in a course, and go to the series setting after that => "Chat for live events" should not be shown and the live-chat must not be activated at all!
- Now enable the "Activate Chat" plugin config again, go back to the last step and check the series setting "Chat for live events" => it must be displayed but disabled by default!