### PR TITLE
[FIX] In plugin configuration: Accessing tab "Metadata" not possible

### DIFF
--- a/src/UI/Metadata/Config/MDConfigTable.php
+++ b/src/UI/Metadata/Config/MDConfigTable.php
@@ -100,7 +100,8 @@ class MDConfigTable extends ilTable2GUI
                 $this->dic->ctrl()->getFormAction($this->parent_obj, 'delete')
             )
             ->withAffectedItems([
-                $this->ui_factory->modal()->interruptiveItem(
+                $this->ui_factory->modal()->interruptiveItem()->keyValue(
+                    $a_set['field_id'],
                     $a_set['field_id'],
                     $a_set['title_de']
                 )


### PR DESCRIPTION
This fixes #406. No review needed FMPOV, it's a trivial change