### PR TITLE
No download per default

### DIFF
--- a/src/UI/ObjectSettings/ObjectSettingsFormItemBuilder.php
+++ b/src/UI/ObjectSettings/ObjectSettingsFormItemBuilder.php
@@ -206,7 +206,7 @@ class ObjectSettingsFormItemBuilder
         $inputs[self::F_MEMBER_DOWNLOAD] = $field_factory->checkbox(
             $this->txt(self::F_MEMBER_DOWNLOAD),
             $this->txt(self::F_MEMBER_DOWNLOAD . '_info')
-        )->withValue(true);
+        );
 
         // Upload
         $inputs[self::F_MEMBER_UPLOAD] = $field_factory->checkbox(


### PR DESCRIPTION
In most cases, it is not desired that a video can be downloaded by the students. Therefore, the download option should not be switched on by default, as many teachers overlook or forget to switch off this option when uploading a video.