### PR TITLE
Search Endpoint Response Conflict resolved

### DIFF
--- a/classes/Player/class.xoctPlayerGUI.php
+++ b/classes/Player/class.xoctPlayerGUI.php
@@ -75,7 +75,7 @@ class xoctPlayerGUI extends xoctGUI
         try {
             $data = PlayerDataBuilderFactory::getInstance()->getBuilder($event)->buildStreamingData();
         } catch (xoctException $e) {
-            xoctLog::getInstance()->logError($e->getCode(), $e->getMessage());
+            xoctLog::getInstance()->logError((string) $e->getCode(), $e->getMessage());
             xoctLog::getInstance()->logStack($e->getTraceAsString());
             $this->sendReponse("Error: " . $e->getMessage());
         }

--- a/src/Util/Player/LivePlayerDataBuilder.php
+++ b/src/Util/Player/LivePlayerDataBuilder.php
@@ -6,6 +6,7 @@ namespace srag\Plugins\Opencast\Util\Player;
 
 use srag\Plugins\Opencast\API\OpencastAPI;
 use srag\Plugins\Opencast\Model\Config\PluginConfig;
+use OpencastApi\Util\OcUtils;
 
 /**
  * Class LivePlayerDataBuilder
@@ -26,13 +27,8 @@ class LivePlayerDataBuilder extends PlayerDataBuilder
             OpencastAPI::RETURN_ARRAY
         );
 
-        //Temporary fix until this issue is fixed in the opencast-php-library:
-        //https://github.com/elan-ev/opencast-php-library/issues/33
-        if (array_key_exists('search-results', $episode_data)) {
-            $media_package = $episode_data['search-results']['result']['mediapackage'];
-        } else {
-            $media_package = $episode_data['result'][0]['mediapackage'];
-        }
+        // Extracting mediapackage from the search endpoint response using OcUtils class from OpencastApi!
+        $media_package = OcUtils::findValueByKey($episode_data, 'mediapackage');
 
         $source_format = PluginConfig::getConfig(PluginConfig::F_LIVESTREAM_BUFFERED) ? 'hls' : 'hlsLive';
         $streams = [];


### PR DESCRIPTION
This PR fixes #429 by using `OcUtils::findValueByKey` to extract mediapackage from search endpoint response, which finds the mediapackage regardsless of the response value structure!

#### IMPORTANT FOR TESTING:
Since the changes are only accessible in the LiveStreaming section of the video player, please make sure that you use your live-stream capable Opencast instance (the community opencast does not have livestream).

**To test:**
- Apart from new Opencast API setup in the setting, if you are using multi-node setup please make sureti add it under `Settings > Events > LIve Stream (enable) > URL Presentation node`