### PR TITLE
Disable OC Studio return target and label

### DIFF
--- a/classes/Event/class.xoctEventGUI.php
+++ b/classes/Event/class.xoctEventGUI.php
@@ -261,6 +261,7 @@ class xoctEventGUI extends xoctGUI
             $b->setCaption('rep_robj_xoct_event_opencast_studio');
             $b->setUrl($this->ctrl->getLinkTarget($this, self::CMD_OPENCAST_STUDIO));
             $b->setPrimary(true);
+            $b->setTarget('_blank');
             $this->toolbar->addButtonInstance($b);
         }
 
@@ -852,16 +853,20 @@ class xoctEventGUI extends xoctGUI
             $studio_link = rtrim((string) $custom_url, "/");
         }
 
-        $return_link = ILIAS_HTTP_PATH . '/'
-            . $this->ctrl->getLinkTarget($this, self::CMD_STANDARD);
-
         // First put the params in an associative array, in order to have a clearer understanding of what is going on!
         $query_params = [
             'upload.seriesId' => $this->objectSettings->getSeriesIdentifier(),
             'upload.seriesField' => 'hidden',
-            'return.label' => 'ILIAS',
-            'return.target' => urlencode($return_link)
         ];
+
+        // The return label and return target parameters for Opencast Studio are temporarily disabled due to an issue.
+        // For more details, see: https://github.com/opencast-ilias/OpenCast/issues/424#issuecomment-3024202623
+
+        /* $return_link = ILIAS_HTTP_PATH . '/'
+            . $this->ctrl->getLinkTarget($this, self::CMD_STANDARD);
+
+        $query_params['return.label'] = 'ILIAS';
+        $query_params['return.target'] = urlencode($return_link); */
 
         // Get the base ACL of the user.
         $acls = $this->ACLUtils->getBaseACLForUser(xoctUser::getInstance($this->user));

--- a/classes/Event/class.xoctEventGUI.php
+++ b/classes/Event/class.xoctEventGUI.php
@@ -38,6 +38,7 @@ use srag\Plugins\Opencast\UI\EventTableBuilder;
 use srag\Plugins\Opencast\UI\Modal\EventModals;
 use srag\Plugins\Opencast\Util\FileTransfer\PaellaConfigStorageService;
 use srag\Plugins\Opencast\Util\Player\PaellaConfigServiceFactory;
+use srag\Plugins\Opencast\Util\Transformator\ACLtoXML;
 use srag\Plugins\OpenCast\UI\Component\Input\Field\Loader;
 use srag\Plugins\Opencast\Model\Cache\Services;
 use srag\Plugins\Opencast\Util\OutputResponse;
@@ -854,9 +855,39 @@ class xoctEventGUI extends xoctGUI
         $return_link = ILIAS_HTTP_PATH . '/'
             . $this->ctrl->getLinkTarget($this, self::CMD_STANDARD);
 
-        $studio_link .= '?upload.seriesId=' . $this->objectSettings->getSeriesIdentifier()
-            . '&return.label=ILIAS'
-            . '&return.target=' . urlencode($return_link);
+        // First put the params in an associative array, in order to have a clearer understanding of what is going on!
+        $query_params = [
+            'upload.seriesId' => $this->objectSettings->getSeriesIdentifier(),
+            'upload.seriesField' => 'hidden',
+            'return.label' => 'ILIAS',
+            'return.target' => urlencode($return_link)
+        ];
+
+        // Get the base ACL of the user.
+        $acls = $this->ACLUtils->getBaseACLForUser(xoctUser::getInstance($this->user));
+
+        // Convert the ACL to Studio ACL notation string.
+        $studio_acl_notation = (new ACLtoXML($acls))->getStudioACLObjectNotation();
+
+        // If ACL notation is not empty, add it to the query parameters array.
+        if (!empty($studio_acl_notation)) {
+            $query_params['upload.acl'] = $studio_acl_notation;
+        }
+
+        // Sort the query parameters array in reverse order to ensure that the parameters are in the correct order.
+        krsort($query_params);
+
+        // Combine the query parameters array into a single query string.
+        $combined_query_string = implode(
+            '&',
+            array_map(function($k, $v){
+                return "$k=$v";
+            }, array_keys($query_params), array_values($query_params))
+        );
+
+        // Append the query string to the studio link.
+        $studio_link .= '?' . $combined_query_string;
+
         $this->ctrl->redirectToURL($studio_link);
     }
 

--- a/src/Util/Transformator/ACLtoXML.php
+++ b/src/Util/Transformator/ACLtoXML.php
@@ -113,4 +113,33 @@ class ACLtoXML
 
         return $xml_writer->xmlDumpMem(false);
     }
+
+
+    /**
+     * Generates a JSON representation of the ACL entries for use in the Opencast Studio Link as upload.acl.
+     *
+     * The JSON format is a nested object where the keys are role names and the values are arrays of actions.
+     * Only entries with an "allow" permission are included.
+     *
+     * @return string The JSON representation of the ACL entries consumable for the Opencast Studio.
+     */
+    public function getStudioACLObjectNotation(): string
+    {
+        $acl_notation_array = [];
+        foreach ($this->acl->getEntries() as $entry) {
+            $role = $entry->getRole();
+            $action = $entry->getAction();
+            $allow = $entry->isAllow();
+            if ($allow) {
+                if (!isset($acl_notation_array[$role])) {
+                    $acl_notation_array[$role] = [];
+                }
+                if (!in_array($action, $acl_notation_array[$role])) {
+                    $acl_notation_array[$role][] = $action;
+                }
+            }
+        }
+        $acl_notation_string = !empty($acl_notation_array) ? json_encode($acl_notation_array) : '';
+        return $acl_notation_string;
+    }
 }

--- a/vendor/composer/autoload_classmap.php
+++ b/vendor/composer/autoload_classmap.php
@@ -180,6 +180,8 @@ return array(
     'srag\\Plugins\\Opencast\\Model\\Workflow\\WorkflowRepository' => $baseDir . '/src/Model/Workflow/WorkflowRepository.php',
     'srag\\Plugins\\Opencast\\UI\\EventFormBuilder' => $baseDir . '/src/UI/EventFormBuilder.php',
     'srag\\Plugins\\Opencast\\UI\\EventTableBuilder' => $baseDir . '/src/UI/EventTableBuilder.php',
+    'srag\\Plugins\\Opencast\\UI\\Integration\\Commons' => $baseDir . '/src/UI/Integration/Commons.php',
+    'srag\\Plugins\\Opencast\\UI\\Integration\\Events' => $baseDir . '/src/UI/Integration/Events.php',
     'srag\\Plugins\\Opencast\\UI\\Integration\\Integration' => $baseDir . '/src/UI/Integration/Integration.php',
     'srag\\Plugins\\Opencast\\UI\\Integration\\MyEvents' => $baseDir . '/src/UI/Integration/MyEvents.php',
     'srag\\Plugins\\Opencast\\UI\\LegacyFormWrapper' => $baseDir . '/src/UI/LegacyFormWrapper.php',

--- a/vendor/composer/autoload_static.php
+++ b/vendor/composer/autoload_static.php
@@ -248,6 +248,8 @@ class ComposerStaticInit20975cba620fc47d8c392214bb856b0a
         'srag\\Plugins\\Opencast\\Model\\Workflow\\WorkflowRepository' => __DIR__ . '/../..' . '/src/Model/Workflow/WorkflowRepository.php',
         'srag\\Plugins\\Opencast\\UI\\EventFormBuilder' => __DIR__ . '/../..' . '/src/UI/EventFormBuilder.php',
         'srag\\Plugins\\Opencast\\UI\\EventTableBuilder' => __DIR__ . '/../..' . '/src/UI/EventTableBuilder.php',
+        'srag\\Plugins\\Opencast\\UI\\Integration\\Commons' => __DIR__ . '/../..' . '/src/UI/Integration/Commons.php',
+        'srag\\Plugins\\Opencast\\UI\\Integration\\Events' => __DIR__ . '/../..' . '/src/UI/Integration/Events.php',
         'srag\\Plugins\\Opencast\\UI\\Integration\\Integration' => __DIR__ . '/../..' . '/src/UI/Integration/Integration.php',
         'srag\\Plugins\\Opencast\\UI\\Integration\\MyEvents' => __DIR__ . '/../..' . '/src/UI/Integration/MyEvents.php',
         'srag\\Plugins\\Opencast\\UI\\LegacyFormWrapper' => __DIR__ . '/../..' . '/src/UI/LegacyFormWrapper.php',


### PR DESCRIPTION
This PR fixes #424,

### What is new:
- The change regarding ACL and hidden series for the studio has been cherry picked and applied here from release_8 branch, which has been merged in PR #396

- The Studio button now open up a new tab and no label and target is sent to the studio