### PR TITLE
Fix Missing startTime Metadata Field Exception

### DIFF
--- a/classes/Conf/PublicationUsage/class.xoctPublicationUsageGUI.php
+++ b/classes/Conf/PublicationUsage/class.xoctPublicationUsageGUI.php
@@ -232,6 +232,7 @@ class xoctPublicationUsageGUI extends xoctGUI
          */
         $xoctPublicationUsage = $this->repository->getUsage($this->identifier);
         $confirm = new ilConfirmationGUI();
+        $confirm->setHeaderText($this->getLocaleString('confirm_delete_text'));
         $confirm->addItem(self::IDENTIFIER, $xoctPublicationUsage->getUsageId(), $xoctPublicationUsage->getTitle());
         $confirm->setFormAction($this->ctrl->getFormAction($this));
         $confirm->setCancel($this->getLocaleString(self::CMD_CANCEL), self::CMD_CANCEL);

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -699,6 +699,7 @@ publication_usage_table_title_usage_group#:#Unternutzungsgruppe
 publication_usage_create_group#:#Unternutzungsgruppe erstellen
 publication_usage_edit_group#:#Unternutzungsgruppe bearbeiten
 publication_usage_confirm_delete_text_group#:#Sind Sie sicher, dass Sie diese Unternutzungsgruppe löschen möchten?
+publication_usage_confirm_delete_text#:#Sind Sie sicher, dass Sie diese Publikationsnutzung löschen möchten?
 publication_usage_extra_config#:#Zusätzliche
 pug_display_name_default#:#Mehr
 publication_usage_type_captions#:#Captions

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -703,6 +703,7 @@ publication_usage_table_title_usage_group#:#Publication Groups
 publication_usage_create_group#:#Create Group
 publication_usage_edit_group#:#Edit Group
 publication_usage_confirm_delete_text_group#:#Are you sure you want to delete this publication group?
+publication_usage_confirm_delete_text#:#Are you sure you want to delete this publication usage?
 publication_usage_extra_config#:#Extras
 publication_usage_type_captions#:#Captions
 publication_usage_type_captions_fallback#:#Captions Fallback

--- a/src/Util/Transformator/MetadataToXML.php
+++ b/src/Util/Transformator/MetadataToXML.php
@@ -7,6 +7,7 @@ namespace srag\Plugins\Opencast\Util\Transformator;
 use ilDateTime;
 use ilXmlWriter;
 use srag\Plugins\Opencast\Model\Metadata\Metadata;
+use xoctException;
 
 /**
  * Class MetadataToXML
@@ -46,12 +47,23 @@ class MetadataToXML
         $xml_writer->xmlElement('dcterms:spatial', [], $this->metadata->getField('location')->getValue());
         $xml_writer->xmlElement('dcterms:rightsHolder', [], $this->metadata->getField('rightsHolder')->getValue());
 
+        // Get start date and time with fallback to current date/time if not provided
+        try {
+            $start_date = $this->metadata->getField('startDate')->getValueFormatted();
+        } catch (xoctException $e) {
+            // If startDate field doesn't exist, use current date
+            $start_date = date('Y-m-d');
+        }
+        
+        try {
+            $start_time = $this->metadata->getField('startTime')->getValueFormatted();
+        } catch (xoctException $e) {
+            // If startTime field doesn't exist, use current time or 00:00:00 as default
+            $start_time = '00:00:00';
+        }
+
         $start_end_string_iso = (new ilDateTime(
-            strtotime(
-                $this->metadata->getField('startDate')->getValueFormatted() . ' ' . $this->metadata->getField(
-                    'startTime'
-                )->getValueFormatted()
-            ),
+            strtotime($start_date . ' ' . $start_time),
             IL_CAL_UNIX
         )
         )->get(IL_CAL_FKT_DATE, 'Y-m-d\TH:i:s.u\Z', 'GMT');


### PR DESCRIPTION
Fixed a critical bug where the OpenCast plugin would throw an xoctException with the message "could not find metadata field with id startTime" when uploading content with preview images enabled but timestamp disabled.

Problem
When creating a regular upload event (not scheduled), the startDate and startTime metadata fields are not automatically added to the metadata catalogue. However, the MetadataToXML transformer assumed these fields would always be present, causing the plugin to crash during the upload process.

---

Fixed a critical bug where the OpenCast plugin would throw an Exception when trying to delete a publication.

Problem
When trying to delete something the HeaderText was not Set.

Stack trace location:

Solution
Modified the MetadataToXML::getXML() method to handle missing startDate and startTime fields gracefully:

Added try-catch blocks around metadata field access
Provides sensible fallback values:
startDate: Current date if field is missing
startTime: 00:00:00 if field is missing
Maintains backward compatibility with existing scheduled events that have these fields
Changes Made
File: src/Util/Transformator/MetadataToXML.php
Added exception handling for missing startDate field (fallback to current date)
Added exception handling for missing startTime field (fallback to 00:00:00)
Added import for xoctException class