### PR TITLE
[FIX] issue with chat layout due to missing bootstrap.css

### DIFF
--- a/src/Chat/GUI/ChatGUI.php
+++ b/src/Chat/GUI/ChatGUI.php
@@ -6,8 +6,6 @@ namespace srag\Plugins\Opencast\Chat\GUI;
 
 use ilOpenCastPlugin;
 use ilTemplate;
-use ilTemplateException;
-use srag\Plugins\Opencast\Chat\Model\ChatroomAR;
 use srag\Plugins\Opencast\Chat\Model\ConfigAR;
 use srag\Plugins\Opencast\Chat\Model\TokenAR;
 use srag\Plugins\Opencast\Container\Init;
@@ -59,14 +57,21 @@ class ChatGUI
             'REFRESH_ICON',
             $this->plugin->getDirectory() . '/src/Chat/node/public/images/refresh_icon.png'
         );
-        $chat_css_path = $this->plugin->getDirectory() . '/src/Chat/node/public/css/chat.css';
-        if (!$async) {
-            $this->template->addCss($chat_css_path);
-        } else {
-            $template->setCurrentBlock('css');
-            $template->setVariable('CSS_PATH', $chat_css_path);
-            $template->parseCurrentBlock();
+        $needed_css = [
+            $this->plugin->getDirectory() . '/src/Chat/node/public/css/chat.css',
+            $this->plugin->getDirectory() . '/templates/default/Chat/bootstrap.min.css',
+        ];
+
+        foreach ($needed_css as $css) {
+            if (!$async) {
+                $this->template->addCss($css);
+            } else {
+                $template->setCurrentBlock('css');
+                $template->setVariable('CSS_PATH', $css);
+                $template->parseCurrentBlock();
+            }
         }
+
         return $template->get();
     }
 }


### PR DESCRIPTION
@dagraf as already mentioned in Matrix, I had to approach this issue ‘blindly’ because i don't have an environment with a chat function in which i can test it. i have now tried to integrate the existing bootsrap.css from the plugin. can you try it out on your test server to see if that solves the problem? i haven't created a ReviewApp because the chat wouldn't be active there either.