### PR TITLE
Disable cutting Option

### DIFF
--- a/classes/Conf/class.xoctConfFormGUI.php
+++ b/classes/Conf/class.xoctConfFormGUI.php
@@ -333,6 +333,14 @@ class xoctConfFormGUI extends ilPropertyFormGUI
         $cbs2->setRequired(false);
         $cbs->addSubItem($cbs2);
 
+        // ENABLE CUTTING
+        $cb = new ilCheckboxInputGUI(
+            $this->getLocaleString(PluginConfig::F_ENABLE_CUTTING),
+            PluginConfig::F_ENABLE_CUTTING
+        );
+        $cb->setInfo($this->getLocaleString(PluginConfig::F_ENABLE_CUTTING . '_info'));
+        $this->addItem($cb);
+
         // MODALS
         $cb = new ilCheckboxInputGUI($this->getLocaleString(PluginConfig::F_USE_MODALS), PluginConfig::F_USE_MODALS);
         $cb->setInfo($this->getLocaleString(PluginConfig::F_USE_MODALS . '_info'));

--- a/classes/Event/class.xoctEventRenderer.php
+++ b/classes/Event/class.xoctEventRenderer.php
@@ -661,7 +661,8 @@ class xoctEventRenderer
         }
 
         // Cut Event
-        if (ilObjOpenCastAccess::checkAction(ilObjOpenCastAccess::ACTION_CUT, $this->event, $xoctUser)) {
+        if (PluginConfig::getConfig(PluginConfig::F_ENABLE_CUTTING)
+            && ilObjOpenCastAccess::checkAction(ilObjOpenCastAccess::ACTION_CUT, $this->event, $xoctUser)) {
             $actions[] = $this->factory->link()->standard(
                 $this->plugin->txt('event_cut'),
                 $this->ctrl->getLinkTargetByClass(xoctEventGUI::class, xoctEventGUI::CMD_CUT)

--- a/classes/Setup/class.ilOpenCastDBUpdateSteps.php
+++ b/classes/Setup/class.ilOpenCastDBUpdateSteps.php
@@ -131,4 +131,25 @@ class ilOpenCastDBUpdateSteps implements \ilDatabaseUpdateSteps
             ]
         );
     }
+
+    /**
+     * This step sets the default value for the "Enable Cutting" configuration to false (off).
+     */
+    public function step_6(): void
+    {
+        // Check if the configuration already exists
+        $r = $this->db->query("SELECT name FROM xoct_config WHERE name = 'enable_cutting'");
+        if ($r->rowCount() > 0) {
+            return;
+        }
+
+        // Insert the default configuration value (false)
+        $this->db->insert(
+            'xoct_config',
+            [
+                'name' => ['text', 'enable_cutting'],
+                'value' => ['text', json_encode(false)]
+            ]
+        );
+    }
 }

--- a/classes/Setup/class.ilOpenCastDBUpdateSteps.php
+++ b/classes/Setup/class.ilOpenCastDBUpdateSteps.php
@@ -133,7 +133,7 @@ class ilOpenCastDBUpdateSteps implements \ilDatabaseUpdateSteps
     }
 
     /**
-     * This step sets the default value for the "Enable Cutting" configuration to false (off).
+     * This step sets the default value for the "Enable Cutting" configuration to true (on).
      */
     public function step_6(): void
     {
@@ -143,12 +143,12 @@ class ilOpenCastDBUpdateSteps implements \ilDatabaseUpdateSteps
             return;
         }
 
-        // Insert the default configuration value (false)
+        // Insert the default configuration value (true)
         $this->db->insert(
             'xoct_config',
             [
                 'name' => ['text', 'enable_cutting'],
-                'value' => ['text', json_encode(false)]
+                'value' => ['text', json_encode(true)]
             ]
         );
     }

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -182,6 +182,8 @@ config_presign_links#:#Presign (experimental)
 config_presign_links_info#:#Wenn aktiv, werden die Links bereits signiert von Opencast ausgeliefert. Dies kann die Performanz beeinflussen. Beachten Sie, dass obige Konfiguration trotzdem benötigt wird, da in gewissen Situationen Links vom Plugin signiert werden müssen.
 config_enable_chat#:#Chat aktivieren
 config_enable_chat_info#:#Aktiviert einen On-screen Chat neben dem Live-Event. Diese Option muss zusätzlich in den Einstellungen eines Objektes aktiviert werden, um wirksam zu werden.
+config_enable_cutting#:#Schneiden aktivieren
+config_enable_cutting_info#:#Ermöglicht es Benutzern, auf das Schnittwerkzeug (Video-Editor) für Videos zuzugreifen. Wenn deaktiviert, ist die Aktion "Schneiden" nicht im Aktionsmenü der Ereignisse verfügbar.
 config_ingest_upload#:#Upload via Ingest-Nodes
 config_ingest_upload_info#:#Wenn aktiv, wird der Upload über Ingest-Nodes statt über die External-API ausgeführt. Dadurch kann die Last auf dem Opencast-Server bei mehreren gleichzeitigen Uploads besser verteilt werden. Achtung: Dazu muss der REST-Endpunkt /ingest für den ILIAS-Server erreichbar und für den API-Benutzer zugänglich sein.
 event_add_new#:#Aufzeichnung hochladen

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -183,6 +183,8 @@ config_presign_links#:#Presign (experimental)
 config_presign_links_info#:#If active, links will be presigned by Opencast. This may impact the performance. Note that the above configuration is still necessary because links will still have to be signed by the plugin in certain situations.
 config_enable_chat#:#Activate Chat
 config_enable_chat_info#:#Enables an on-screen chat beside the Live Event. This option must additionally be set in the settings of an object to be effective.
+config_enable_cutting#:#Enable Cutting
+config_enable_cutting_info#:#Allow users to access the cutting tool (Video Editor) for videos. When disabled, the "Cut" action will not be available in the event actions menu.
 config_ingest_upload#:#Upload via Ingest Nodes
 config_ingest_upload_info#:#If enabled, the upload will be executed via ingest nodes instead of the external API. This improves the load distribution on the Opencast server when uploading multiple files simultaneously. Note that the REST endpoint /ingest has to be available for the ILIAS server and the API user.
 eula#:#Terms of Use

--- a/src/Model/Config/PluginConfig.php
+++ b/src/Model/Config/PluginConfig.php
@@ -87,6 +87,7 @@ class PluginConfig extends ActiveRecord
     public const F_LIVESTREAM_TYPE = 'livestream_type';
     public const F_LIVESTREAM_BUFFERED = 'livestream_buffered';
     public const F_ENABLE_CHAT = 'enable_chat';
+    public const F_ENABLE_CUTTING = 'enable_cutting';
 
     public const F_REPORT_QUALITY = 'report_quality';
     public const F_REPORT_QUALITY_EMAIL = 'report_quality_email';


### PR DESCRIPTION
This pull request introduces a new "Enable Cutting" feature, which allows administrators to control whether users can access the video cutting tool (editor) for events. The feature is configurable, disabled by default, and is reflected in both the UI and permissions logic.