### PR TITLE
fix for getting the user who reported a problem

### DIFF
--- a/src/Model/Report/Report.php
+++ b/src/Model/Report/Report.php
@@ -49,6 +49,7 @@ class Report extends ActiveRecord
                 $this->getRecipientForType($this->getType()),
                 $this->getSubject(),
                 $this->getMessage(),
+                $this->getUserId()
             );
         }
     }


### PR DESCRIPTION
This fix will make sure when a users reports a problem, the mail that is sent will have the right user in the reply-to.
This Problem was mentioned by Christoph Reifers in the matrix chat and we already have this solution on our servers.