### PR TITLE
Align keyboard shortcut rewind with button 10s in Paella Player

### DIFF
--- a/js/opencast/src/Paella/config/config.json
+++ b/js/opencast/src/Paella/config/config.json
@@ -449,7 +449,9 @@
     },
     "es.upv.paella.defaultShortcuts": {
       "enabled": true,
-      "validPlaybackRates": [0.75, 1, 1.25, 1.5, 1.75, 2.0, 2.5, 3.0]
+      "validPlaybackRates": [0.75, 1, 1.25, 1.5, 1.75, 2.0, 2.5, 3.0],
+      "skipBackwards": 10,
+      "skipForward": 30
     },
     "es.upv.paella.arrowSlidesNavigator": {
       "enabled": false,


### PR DESCRIPTION
This PR fixes #491 

It only adds the default shortcut values for backward and forward rewinding, aligned with the button values.

This could be simply cherry-picked to `release_10` as well.