### PR TITLE
[FIX] Sort event list by series name and correct sort direction

### DIFF
--- a/src/UI/Integration/MyEvents.php
+++ b/src/UI/Integration/MyEvents.php
@@ -421,33 +421,12 @@ class MyEvents implements DataRetrieval
             $filter = array_filter($filter, static fn($value): bool => $value !== '');
             $filter['status'] = 'EVENTS.EVENTS.STATUS.PROCESSED';
 
-            // The Opencast API can only sort by an event's own metadata (e.g.
-            // title), not by the resolved series *name* shown in the table - it
-            // only knows the series identifier. Sorting by series is therefore
-            // done locally. As the result is paginated server-side, we fetch the
-            // full result set, sort it by series name (respecting the requested
-            // direction) and slice the requested page ourselves; otherwise only
-            // the current page would be reordered and the overall order across
-            // pages would be wrong.
+            // The event list "series" column is sorted by the series name.
+            // Opencast supports this natively through the `series_name` sort
+            // criterion, so we let the API sort the full result set server-side
+            // and paginate correctly across all pages.
             if ($sort === 'series') {
-                $events = $this->event_repository->getFiltered(
-                    $filter,
-                    '',
-                    [$xoct_user->getUserRoleName()],
-                    0,
-                    1000,
-                    'title:ASC',
-                    true
-                );
-
-                usort(
-                    $events,
-                    fn(Event $a, Event $b): int => $order === 'DESC'
-                        ? strnatcasecmp($this->getSeriesName($b), $this->getSeriesName($a))
-                        : strnatcasecmp($this->getSeriesName($a), $this->getSeriesName($b))
-                );
-
-                return array_slice($events, $offset, $limit);
+                $sort = 'series_name';
             }
 
             $events = $this->event_repository->getFiltered(

--- a/src/UI/Integration/MyEvents.php
+++ b/src/UI/Integration/MyEvents.php
@@ -441,14 +441,15 @@ class MyEvents implements DataRetrieval
         }
 
         if ($sort__by_series) {
+            // Sort by the displayed series name (not the series identifier) and respect the requested direction.
             usort(
                 $events,
-                static fn(Event $a, Event $b): int => $order === 'DESC' ? strnatcasecmp(
-                    $a->getSeries(),
-                    $b->getSeries()
+                fn(Event $a, Event $b): int => $order === 'DESC' ? strnatcasecmp(
+                    $this->getSeriesName($b),
+                    $this->getSeriesName($a)
                 ) : strnatcasecmp(
-                    $b->getSeries(),
-                    $a->getSeries()
+                    $this->getSeriesName($a),
+                    $this->getSeriesName($b)
                 )
             );
         }

--- a/src/UI/Integration/MyEvents.php
+++ b/src/UI/Integration/MyEvents.php
@@ -421,10 +421,33 @@ class MyEvents implements DataRetrieval
             $filter = array_filter($filter, static fn($value): bool => $value !== '');
             $filter['status'] = 'EVENTS.EVENTS.STATUS.PROCESSED';
 
-            $sort__by_series = false;
+            // The Opencast API can only sort by an event's own metadata (e.g.
+            // title), not by the resolved series *name* shown in the table - it
+            // only knows the series identifier. Sorting by series is therefore
+            // done locally. As the result is paginated server-side, we fetch the
+            // full result set, sort it by series name (respecting the requested
+            // direction) and slice the requested page ourselves; otherwise only
+            // the current page would be reordered and the overall order across
+            // pages would be wrong.
             if ($sort === 'series') {
-                $sort = 'title';
-                $sort__by_series = true;
+                $events = $this->event_repository->getFiltered(
+                    $filter,
+                    '',
+                    [$xoct_user->getUserRoleName()],
+                    0,
+                    1000,
+                    'title:ASC',
+                    true
+                );
+
+                usort(
+                    $events,
+                    fn(Event $a, Event $b): int => $order === 'DESC'
+                        ? strnatcasecmp($this->getSeriesName($b), $this->getSeriesName($a))
+                        : strnatcasecmp($this->getSeriesName($a), $this->getSeriesName($b))
+                );
+
+                return array_slice($events, $offset, $limit);
             }
 
             $events = $this->event_repository->getFiltered(
@@ -438,20 +461,6 @@ class MyEvents implements DataRetrieval
             );
         } catch (\Throwable) {
             return [];
-        }
-
-        if ($sort__by_series) {
-            // Sort by the displayed series name (not the series identifier) and respect the requested direction.
-            usort(
-                $events,
-                fn(Event $a, Event $b): int => $order === 'DESC' ? strnatcasecmp(
-                    $this->getSeriesName($b),
-                    $this->getSeriesName($a)
-                ) : strnatcasecmp(
-                    $this->getSeriesName($a),
-                    $this->getSeriesName($b)
-                )
-            );
         }
         // we cannot filter by processing state here, as the api does not deliver this information directly ant this
         // would lead to non mathcing amount of rows. e.g. if 5 events should be displayed, but only 3 are processed,


### PR DESCRIPTION
Sorts the event list by the displayed series name instead of the series UUID and corrects the swapped ASC/DESC direction. Fixes opencast-ilias/OpencastPageComponent#43.