### PR TITLE
[FIX] Opencast down: fast connect timeout + readable message #365

### DIFF
--- a/classes/Conf/class.xoctConfFormGUI.php
+++ b/classes/Conf/class.xoctConfFormGUI.php
@@ -164,6 +164,16 @@ class xoctConfFormGUI extends ilPropertyFormGUI
         $te->setRequired(true);
         $this->addItem($te);
 
+        $ni = new ilNumberInputGUI(
+            $this->getLocaleString(PluginConfig::F_API_CONNECT_TIMEOUT),
+            PluginConfig::F_API_CONNECT_TIMEOUT
+        );
+        $ni->setInfo($this->getLocaleString(PluginConfig::F_API_CONNECT_TIMEOUT . '_info'));
+        $ni->setSuffix('ms');
+        $ni->setMinValue(0);
+        $ni->allowDecimals(false);
+        $this->addItem($ni);
+
         $te = new ilTextInputGUI($this->getLocaleString(PluginConfig::F_CURL_USERNAME), PluginConfig::F_CURL_USERNAME);
         $te->setInfo($this->getLocaleString(PluginConfig::F_CURL_USERNAME . '_info'));
         $te->setRequired(true);

--- a/classes/Event/class.xoctEventGUI.php
+++ b/classes/Event/class.xoctEventGUI.php
@@ -274,11 +274,20 @@ class xoctEventGUI extends xoctGUI
             $this->objectSettings
         );
 
-        $this->main_tpl->setContent(
-            $this->ui_renderer->render(
+        try {
+            $content = $this->ui_renderer->render(
                 array_filter(array_merge($display_series->get(), [$modal]))
-            )
-        );
+            );
+        } catch (xoctException $e) {
+            // Opencast is unreachable: show a readable message instead of the generic ILIAS error page.
+            if ($e->getCode() === xoctException::API_CALL_CONNECTION_FAILED) {
+                $this->main_tpl->setOnScreenMessage('failure', $this->txt('msg_opencast_unreachable'), true);
+                return;
+            }
+            throw $e;
+        }
+
+        $this->main_tpl->setContent($content);
 
         // Report Date Modification Modal: This is a absolute mess... The Button ist added anyway in prepareContent, but "hidden".
         // Only if the Series has sceduled events, it gets shown via js.

--- a/classes/Event/class.xoctEventGUI.php
+++ b/classes/Event/class.xoctEventGUI.php
@@ -279,9 +279,11 @@ class xoctEventGUI extends xoctGUI
                 array_filter(array_merge($display_series->get(), [$modal]))
             );
         } catch (xoctException $e) {
-            // Opencast is unreachable: show a readable message instead of the generic ILIAS error page.
+            // Opencast is unreachable: show a readable message instead of the generic ILIAS error
+            // page. The message must not be kept, it belongs on the page being rendered right now
+            // and not on whatever the user opens next.
             if ($e->getCode() === xoctException::API_CALL_CONNECTION_FAILED) {
-                $this->main_tpl->setOnScreenMessage('failure', $this->txt('msg_opencast_unreachable'), true);
+                $this->main_tpl->setOnScreenMessage('failure', $this->txt('msg_opencast_unreachable'));
                 return;
             }
             throw $e;

--- a/classes/class.ilObjOpenCastListGUI.php
+++ b/classes/class.ilObjOpenCastListGUI.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use srag\Plugins\Opencast\Model\Config\PluginConfig;
 use srag\Plugins\Opencast\Model\Object\ObjectSettings;
+use srag\Plugins\Opencast\Util\OpencastAvailability;
 
 /**
  * ListGUI implementation for OpenCast object plugin. This one
@@ -104,6 +105,19 @@ class ilObjOpenCastListGUI extends ilObjectPluginListGUI
     public function getCustomProperties(/*array*/ $prop): array
     {
         $props = parent::getCustomProperties([]);
+
+        // A container can hold many series, so Opencast is not asked once per object here.
+        // Instead the last known connection failure is read, see OpencastAvailability.
+        if (OpencastAvailability::isUnreachable()) {
+            $props[] = [
+                'alert' => true,
+                'newline' => true,
+                'property' => 'Status',
+                'value' => $this->txt('event_msg_opencast_unreachable'),
+                'propertyNameVisible' => false
+            ];
+        }
+
         try {
             $objectSettings = $this->getOpenCast(true);
             if (!$objectSettings instanceof ObjectSettings) {

--- a/classes/class.xoctException.php
+++ b/classes/class.xoctException.php
@@ -23,10 +23,13 @@ class xoctException extends Exception
     public const API_CALL_STATUS_409 = 409;
     public const API_CALL_BAD_CREDENTIALS = 401;
     public const API_CALL_BAD_REQUEST = 400;
+    // No HTTP response received (connection refused / timeout / DNS) - Opencast is unreachable.
+    public const API_CALL_CONNECTION_FAILED = 0;
     /**
      * @var array
      */
     protected static $messages = [
+        self::API_CALL_CONNECTION_FAILED => 'Opencast cannot be reached at the moment.',
         self::API_CALL_UNSUPPORTED => 'This Api-Call is not supported',
         self::API_CALL_STATUS_500 => 'An error occurred while communicating with the OpenCast-Server',
         self::API_CALL_STATUS_403 => 'Access denied',

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -24,6 +24,8 @@ config_activate_cache_2_info#:#Daten werden in der ILIAS-Datenbank zwischengespe
 config_annotation_token_security#:#Anmerkungs-Token-Sicherheit aktivieren
 config_annotation_token_security_info#:#Fügt die Kursreferenz und einen Sicherheitshash zum Annotationslink hinzu.
 config_api_base#:#API-Basis-URL
+config_api_connect_timeout#:#API-Verbindungs-Timeout
+config_api_connect_timeout_info#:#Maximale Wartezeit in Millisekunden für den Verbindungsaufbau zu Opencast, bevor abgebrochen wird. Verhindert lange Ladezeiten, wenn Opencast nicht erreichbar ist. 0 = kein Limit. Standard: 5000.
 config_api_version#:#API-Version
 config_api_version_info#:#Format: vX.Y.Z - z.B.: v1.0.0
 config_curl_max_upload_size#:#Maximale Upload-Größe in MB
@@ -220,6 +222,7 @@ event_msg_deleted#:#Aufzeichnung gelöscht
 event_msg_unpublish_started#:#Die Publikationen werden nun entfernt.
 event_msg_currently_unpublishing#:#Der Prozess zum Entfernen der Publikationen läuft bereits.
 event_msg_no_access#:#kein Zugriff
+event_msg_opencast_unreachable#:#Opencast ist zurzeit nicht erreichbar. Bitte melden Sie sich bei Ihrer Supportstelle.
 event_msg_no_download_publication#:#Die Download-Publikation konnte nicht gefunden werden.
 event_msg_success#:#Änderungen gespeichert
 event_msg_scheduled#:#Aufzeichnungstermin(e) erstellt.

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -24,6 +24,8 @@ config_activate_cache_2_info#:#Data will be cached in the ILIAS database.
 config_annotation_token_security#:#Enable Annotation token security
 config_annotation_token_security_info#:#Adds the course reference and a security hash to the annotation link
 config_api_base#:#API base URL
+config_api_connect_timeout#:#API connection timeout
+config_api_connect_timeout_info#:#Maximum time in milliseconds to wait while connecting to Opencast before aborting. Prevents long page loads when Opencast is unreachable. 0 = no limit. Default: 5000.
 config_api_version#:#API Version
 config_api_version_info#:#Format: vX.Y.Z - e.g.: v1.0.0
 config_curl_max_upload_size#:#Max. File-Size in MB
@@ -221,6 +223,7 @@ event_msg_deleted#:#Event deleted
 event_msg_unpublish_started#:#The publications are now being removed.
 event_msg_currently_unpublishing#:#The process to remove the publications is already running.
 event_msg_no_access#:#No Access
+event_msg_opencast_unreachable#:#Opencast is currently unreachable. Please contact your support.
 event_msg_no_download_publication#:#The download publication could not be found.
 event_msg_success#:#Saved changes
 event_msg_scheduled#:#Event(s) scheduled

--- a/src/API/DecorateProxy.php
+++ b/src/API/DecorateProxy.php
@@ -85,7 +85,11 @@ class DecorateProxy
             $resp_orig_text .= ' => ' . $reason;
 
             match ($code) {
-                0 => throw new xoctException(xoctException::API_CALL_CONNECTION_FAILED, $resp_orig_text),
+                // 0: Opencast unreachable with no proxy in front. 502 Bad Gateway /
+                // 504 Gateway Timeout: a reverse proxy reports the Opencast behind it
+                // as down or unresponsive. All three mean "cannot reach Opencast", so
+                // show the connection-failed message instead of a generic server error.
+                0, 502, 504 => throw new xoctException(xoctException::API_CALL_CONNECTION_FAILED, $resp_orig_text),
                 403 => throw new xoctException(xoctException::API_CALL_STATUS_403, $resp_orig_text),
                 401 => throw new xoctException(xoctException::API_CALL_BAD_CREDENTIALS),
                 404 => throw new xoctException(xoctException::API_CALL_STATUS_404, $resp_orig_text),

--- a/src/API/DecorateProxy.php
+++ b/src/API/DecorateProxy.php
@@ -8,6 +8,7 @@ use xoctLog;
 use xoctException;
 use GuzzleHttp\Client;
 use OpencastApi\Rest\OcRest;
+use srag\Plugins\Opencast\Util\OpencastAvailability;
 
 /**
  * Class srag\Plugins\Opencast\API\DecorateProxy
@@ -18,6 +19,12 @@ use OpencastApi\Rest\OcRest;
  */
 class DecorateProxy
 {
+    /**
+     * HTTP codes which mean the Opencast server itself could not be reached: 0 (no response at
+     * all), 502 and 504 (a proxy in front of Opencast reporting it as down or unresponsive).
+     */
+    private const CONNECTION_FAILURE_CODES = [0, 502, 504];
+
     public function __construct(public ?OcRest $object)
     {
     }
@@ -84,12 +91,14 @@ class DecorateProxy
 
             $resp_orig_text .= ' => ' . $reason;
 
+            if (in_array($code, self::CONNECTION_FAILURE_CODES, true)) {
+                // Remembered so the repository list can show the hint without asking Opencast
+                // once per object while it is down.
+                OpencastAvailability::rememberUnreachable();
+                throw new xoctException(xoctException::API_CALL_CONNECTION_FAILED, $resp_orig_text);
+            }
+
             match ($code) {
-                // 0: Opencast unreachable with no proxy in front. 502 Bad Gateway /
-                // 504 Gateway Timeout: a reverse proxy reports the Opencast behind it
-                // as down or unresponsive. All three mean "cannot reach Opencast", so
-                // show the connection-failed message instead of a generic server error.
-                0, 502, 504 => throw new xoctException(xoctException::API_CALL_CONNECTION_FAILED, $resp_orig_text),
                 403 => throw new xoctException(xoctException::API_CALL_STATUS_403, $resp_orig_text),
                 401 => throw new xoctException(xoctException::API_CALL_BAD_CREDENTIALS),
                 404 => throw new xoctException(xoctException::API_CALL_STATUS_404, $resp_orig_text),
@@ -98,6 +107,9 @@ class DecorateProxy
                 default => throw new xoctException(xoctException::API_CALL_STATUS_500, $resp_orig_text),
             };
         }
+
+        // Opencast answered, so a remembered outage is over.
+        OpencastAvailability::rememberReachable();
 
         return $return_array ? $this->parseResponseBodyToArray($body) : $body;
     }

--- a/src/API/DecorateProxy.php
+++ b/src/API/DecorateProxy.php
@@ -85,6 +85,7 @@ class DecorateProxy
             $resp_orig_text .= ' => ' . $reason;
 
             match ($code) {
+                0 => throw new xoctException(xoctException::API_CALL_CONNECTION_FAILED, $resp_orig_text),
                 403 => throw new xoctException(xoctException::API_CALL_STATUS_403, $resp_orig_text),
                 401 => throw new xoctException(xoctException::API_CALL_BAD_CREDENTIALS),
                 404 => throw new xoctException(xoctException::API_CALL_STATUS_404, $resp_orig_text),

--- a/src/Container/Init.php
+++ b/src/Container/Init.php
@@ -111,7 +111,7 @@ final class Init
             PluginConfig::getConfig(PluginConfig::F_CURL_PASSWORD) ?? 'opencast',
             PluginConfig::getConfig(PluginConfig::F_API_VERSION) ?? '1.9.0',
             0,
-            0,
+            (int) (PluginConfig::getConfig(PluginConfig::F_API_CONNECT_TIMEOUT) ?? PluginConfig::DEFAULT_API_CONNECT_TIMEOUT),
             PluginConfig::getConfig(PluginConfig::F_PRESENTATION_NODE) ?? null,
             $jwt
         ));

--- a/src/Model/Config/PluginConfig.php
+++ b/src/Model/Config/PluginConfig.php
@@ -44,6 +44,8 @@ class PluginConfig extends ActiveRecord
     public const F_CURL_DEBUG_LEVEL = 'curl_debug_level';
     public const F_API_VERSION = 'api_version';
     public const F_API_BASE = 'api_base';
+    public const F_API_CONNECT_TIMEOUT = 'api_connect_timeout';
+    public const DEFAULT_API_CONNECT_TIMEOUT = 5000;
     public const F_ACTIVATE_CACHE = 'activate_cache';
     public const CACHE_DISABLED = 0;
     public const CACHE_APCU = 1;

--- a/src/Util/OpencastAvailability.php
+++ b/src/Util/OpencastAvailability.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace srag\Plugins\Opencast\Util;
+
+use ilSetting;
+
+/**
+ * Remembers whether the last contact with Opencast ran into a connection failure, meaning no
+ * HTTP response at all or a proxy reporting the Opencast behind it as down.
+ *
+ * The repository list view needs this information for every single object it renders. Asking
+ * Opencast once per object would multiply the loading time of a course page exactly while
+ * Opencast is down, so the state is written whenever a regular API call fails to reach the
+ * server and cleared as soon as any API call succeeds again. Reading it costs one cached
+ * ilSetting lookup.
+ *
+ * @author Fabian Schmid <fabian@sr.solutions>
+ */
+class OpencastAvailability
+{
+    private const MODULE = 'xoct';
+    private const KEY_UNREACHABLE_SINCE = 'unreachable_since';
+
+    private static ?ilSetting $settings = null;
+
+    public static function rememberUnreachable(): void
+    {
+        // Keep the first timestamp: it marks the beginning of the outage, not the last attempt.
+        if (self::settings()->get(self::KEY_UNREACHABLE_SINCE) === null) {
+            self::settings()->set(self::KEY_UNREACHABLE_SINCE, (string) time());
+        }
+    }
+
+    public static function rememberReachable(): void
+    {
+        if (self::settings()->get(self::KEY_UNREACHABLE_SINCE) !== null) {
+            self::settings()->delete(self::KEY_UNREACHABLE_SINCE);
+        }
+    }
+
+    public static function isUnreachable(): bool
+    {
+        return self::settings()->get(self::KEY_UNREACHABLE_SINCE) !== null;
+    }
+
+    private static function settings(): ilSetting
+    {
+        return self::$settings ??= new ilSetting(self::MODULE);
+    }
+}

--- a/vendor/composer/autoload_classmap.php
+++ b/vendor/composer/autoload_classmap.php
@@ -301,6 +301,7 @@ return array(
     'srag\\Plugins\\Opencast\\Util\\Locale\\LocaleTrait' => $baseDir . '/src/Util/Locale/LocaleTrait.php',
     'srag\\Plugins\\Opencast\\Util\\Locale\\Translator' => $baseDir . '/src/Util/Locale/Translator.php',
     'srag\\Plugins\\Opencast\\Util\\MimeType' => $baseDir . '/src/Util/MimeType.php',
+    'srag\\Plugins\\Opencast\\Util\\OpencastAvailability' => $baseDir . '/src/Util/OpencastAvailability.php',
     'srag\\Plugins\\Opencast\\Util\\OutputResponse' => $baseDir . '/src/Util/OutputResponse.php',
     'srag\\Plugins\\Opencast\\Util\\Player\\LivePlayerDataBuilder' => $baseDir . '/src/Util/Player/LivePlayerDataBuilder.php',
     'srag\\Plugins\\Opencast\\Util\\Player\\PaellaConfigService' => $baseDir . '/src/Util/Player/PaellaConfigService.php',

--- a/vendor/composer/autoload_static.php
+++ b/vendor/composer/autoload_static.php
@@ -391,6 +391,7 @@ class ComposerStaticInit20975cba620fc47d8c392214bb856b0a
         'srag\\Plugins\\Opencast\\Util\\Locale\\LocaleTrait' => __DIR__ . '/../..' . '/src/Util/Locale/LocaleTrait.php',
         'srag\\Plugins\\Opencast\\Util\\Locale\\Translator' => __DIR__ . '/../..' . '/src/Util/Locale/Translator.php',
         'srag\\Plugins\\Opencast\\Util\\MimeType' => __DIR__ . '/../..' . '/src/Util/MimeType.php',
+        'srag\\Plugins\\Opencast\\Util\\OpencastAvailability' => __DIR__ . '/../..' . '/src/Util/OpencastAvailability.php',
         'srag\\Plugins\\Opencast\\Util\\OutputResponse' => __DIR__ . '/../..' . '/src/Util/OutputResponse.php',
         'srag\\Plugins\\Opencast\\Util\\Player\\LivePlayerDataBuilder' => __DIR__ . '/../..' . '/src/Util/Player/LivePlayerDataBuilder.php',
         'srag\\Plugins\\Opencast\\Util\\Player\\PaellaConfigService' => __DIR__ . '/../..' . '/src/Util/Player/PaellaConfigService.php',


### PR DESCRIPTION
Fixes #365.

Covers the community decision of 2025-03-11 (readable message in the synchronous content view, in the asynchronous view and in the repository list) for the `release_10` line.

## What it does

- **Fail fast:** configurable API connect timeout, default 5000 ms, so a request to an unreachable Opencast aborts instead of hanging until the PHP or proxy timeout.
- **Recognise "Opencast is down":** the HTTP codes that mean the server itself could not be reached are mapped to a dedicated exception — `0` (no response at all, Opencast without a proxy in front) and `502` / `504` (a reverse proxy reporting the Opencast behind it as down or unresponsive), as suggested in https://github.com/opencast-ilias/OpenCast/issues/365#issuecomment-4727385728.
- **Content view:** readable message box instead of the generic ILIAS error page. The message is no longer stored with the keep flag, which would have shown it one page load too late.
- **Repository list:** the same hint below the object title. The connection failure is remembered when an API call runs into it and forgotten as soon as any API call succeeds again, so a container holding many series does not ask Opencast once per object exactly while it is down (`OpencastAvailability`, one cached `ilSetting` lookup per object).
- No asynchronous case in this line: `release_10` renders the content view synchronously. For the async table/tiles of `release_9` see #507.

No DB update needed; the outage flag lives in the core `settings` table.

## Test

ReviewApp: https://sr-fixes-10.opencast.k8s.sr.solutions

With Opencast (or the proxy in front of it) stopped:

1. Open a series -> message box "Opencast is currently unreachable. Please contact your support." instead of the error code page, and it appears immediately rather than on the next click.
2. Go back to the course/category -> the same hint below the series titles.
3. Start Opencast again and reload -> hint and message are gone.

Also check that a series is still shown normally while Opencast is up, and that other API errors (403, 404, ...) keep their previous behaviour.
