### PR TITLE
[FIX] Event list: fill scheduled-live label + show times in user timezone #498 #499

### DIFF
--- a/src/UI/Integration/Commons.php
+++ b/src/UI/Integration/Commons.php
@@ -45,7 +45,23 @@ trait Commons
         if (is_string($date)) {
             $date = new \DateTimeImmutable($date);
         }
-        return $date->format('d. M Y, H:i');
+        return $date->setTimezone($this->userTimeZone())->format('d. M Y, H:i');
+    }
+
+    /**
+     * The timezone the current user expects dates to be displayed in. Opencast delivers timestamps in
+     * UTC, so they must be converted before display (otherwise scheduled events show the UTC time). See #499.
+     */
+    public function userTimeZone(): \DateTimeZone
+    {
+        if (!isset($this->container) || !$this->container instanceof Container) {
+            return new \DateTimeZone('UTC');
+        }
+        try {
+            return new \DateTimeZone($this->container->ilias()->user()->getTimeZone() ?: 'UTC');
+        } catch (\Throwable) {
+            return new \DateTimeZone('UTC');
+        }
     }
 
 }

--- a/src/UI/Integration/Events.php
+++ b/src/UI/Integration/Events.php
@@ -8,6 +8,7 @@ use ILIAS\UI\Renderer;
 use srag\Plugins\Opencast\Container\Container;
 use srag\Plugins\Opencast\Model\Event\EventAPIRepository;
 use srag\Plugins\Opencast\Model\Event\Event;
+use srag\Plugins\Opencast\Model\Config\PluginConfig;
 use ILIAS\UI\Component\Item\Item;
 use srag\Plugins\Opencast\Model\Series\SeriesAPIRepository;
 use ILIAS\UI\Component\Panel\Panel;
@@ -333,6 +334,18 @@ class Events implements RecordToEntity
     protected function buildStatusComponents(Event $record, EventActionParameters $parameters, Entity $entity): Entity
     {
         $status_label = $this->translate('event_state_' . strtolower($record->getProcessingState()));
+        // The "scheduled live stream" label contains a %s placeholder for the time from which the
+        // stream can be opened. Fill it (the legacy renderer does this; the new UI did not, so the
+        // raw "%s" was shown). See #498.
+        if (
+            $record->getProcessingState() === Event::STATE_LIVE_SCHEDULED
+            && str_contains($status_label, '%s')
+            && $record->getScheduling() !== null
+        ) {
+            $minutes_before_live = (int) PluginConfig::getConfig(PluginConfig::F_START_X_MINUTES_BEFORE_LIVE);
+            $open_from = $record->getScheduling()->getStart()->getTimestamp() - ($minutes_before_live * 60);
+            $status_label = sprintf($status_label, date('d.m.Y, H:i', $open_from));
+        }
         $status_label_short = $this->shortenText(
             $status_label,
             (int) ($this->settings_resolver->resolve(EventSettings::STATUS_MAX_LENGTH) ?? 42)

--- a/src/UI/Integration/Events.php
+++ b/src/UI/Integration/Events.php
@@ -343,8 +343,10 @@ class Events implements RecordToEntity
             && $record->getScheduling() !== null
         ) {
             $minutes_before_live = (int) PluginConfig::getConfig(PluginConfig::F_START_X_MINUTES_BEFORE_LIVE);
-            $open_from = $record->getScheduling()->getStart()->getTimestamp() - ($minutes_before_live * 60);
-            $status_label = sprintf($status_label, date('d.m.Y, H:i', $open_from));
+            $open_from = $record->getScheduling()->getStart()
+                ->modify("-{$minutes_before_live} minutes")
+                ->setTimezone($this->userTimeZone());
+            $status_label = sprintf($status_label, $open_from->format('d.m.Y, H:i'));
         }
         $status_label_short = $this->shortenText(
             $status_label,
@@ -442,7 +444,7 @@ class Events implements RecordToEntity
         }
 
         return $item->withProperties([
-            $this->translate("event_date") => $event->getStart()->format('d.m.Y H:i'),
+            $this->translate("event_date") => $event->getStart()->setTimezone($this->userTimeZone())->format('d.m.Y H:i'),
             $this->translate("event_series") => $this->getSeriesName($event),
             $this->translate("event_presenter") => implode(", ", $event->getPresenter()),
         ])->withLeadImage(


### PR DESCRIPTION
Two related fixes for the event list (new release_10 UI):

- The scheduled-live-stream status tag rendered the raw `%s` placeholder; it is now filled with the scheduled opening time (matching the legacy renderer). Fixes #498.
- Event times were shown in UTC instead of the user's timezone (a live event scheduled for 14:30 CEST appeared as 12:30); times are now converted to the user's timezone before display. Fixes #499.

Note: the remaining live-status correctness items in #498 (items 2-4) are left for the design discussion noted in that issue.