### PR TITLE
[FIX] Thumbnail selection uses duration input instead of datetime picker #485

### DIFF
--- a/classes/Event/class.xoctEventGUI.php
+++ b/classes/Event/class.xoctEventGUI.php
@@ -373,7 +373,7 @@ class xoctEventGUI extends xoctGUI
                 }
 
                 if ($thumbnail_section_data['mode'][0] == 'timepoint' &&
-                    $thumbnail_section_data['mode'][1]['timepoint'] instanceof \DateTimeImmutable) {
+                    !empty($thumbnail_section_data['mode'][1]['timepoint'])) {
                     $thumbnail_timepoint = $thumbnail_section_data['mode'][1]['timepoint'];
                 }
             }
@@ -387,7 +387,7 @@ class xoctEventGUI extends xoctGUI
 
             // Timepoint mode.
             if (isset($thumbnail_section_data['timepoint']) &&
-                $thumbnail_section_data['timepoint'] instanceof \DateTimeImmutable) {
+                !empty($thumbnail_section_data['timepoint'])) {
                 $thumbnail_timepoint = $thumbnail_section_data['timepoint'];
             }
 
@@ -397,12 +397,8 @@ class xoctEventGUI extends xoctGUI
             }
 
             // Taking care of timepoint here and put it in the workflow configuration already.
-            if (!empty($thumbnail_timepoint)) {
-                $formatted_timepoint = $thumbnail_timepoint->format('H:i:s');
-                $timepoint_seconds = strtotime($formatted_timepoint) - strtotime('TODAY');
-                if ($timepoint_seconds > 0) {
-                    $extra_workflow_params->snapshotThumbnailTime = (string) $timepoint_seconds;
-                }
+            if (is_int($thumbnail_timepoint) && $thumbnail_timepoint > 0) {
+                $extra_workflow_params->snapshotThumbnailTime = (string) $thumbnail_timepoint;
             }
         }
 

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -785,7 +785,8 @@ upload_ui_thumbnail_mode_sg_file#:#Durch Hochladen einer Datei
 upload_ui_thumbnail_mode_sg_timepoint#:#Durch Auswahl eines Videozeitpunkts
 upload_ui_thumbnail_file#:#Vorschaubilddatei
 upload_ui_thumbnail_timepoint#:#Zeitpunkt
-upload_ui_thumbnail_timepoint_info#:#Der Zeitpunkt des Videos, aus dem das Vorschaubild extrahiert werden soll.
+upload_ui_thumbnail_timepoint_info#:#Der Zeitpunkt des Videos, aus dem das Vorschaubild extrahiert werden soll. Format: HH:MM:SS (z.B. 00:01:30 für 1 Minute 30 Sekunden).
+upload_ui_thumbnail_timepoint_invalid#:#Ungültiges Format. Bitte HH:MM:SS verwenden (z.B. 00:01:30).
 show_more#:#Mehr
 title_asc#:#Titel A-Z
 title_desc#:#Titel Z-A

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -785,7 +785,7 @@ upload_ui_thumbnail_section_stp_disabled_info#:#<strong>NOTE:</strong> The proce
 upload_ui_thumbnail_mode_sg#:#Mode
 upload_ui_thumbnail_mode_sg_info#:#You can select only one mode to generate thumbnails, either by uploading a file or selecting a timepoint.
 upload_ui_thumbnail_mode_sg_file#:#By uploading a file
-upload_ui_thumbnail_mode_sg_timepoint#:#By selecting a video tiempoint
+upload_ui_thumbnail_mode_sg_timepoint#:#By selecting a video timepoint
 upload_ui_thumbnail_file#:#Thumbnail File
 upload_ui_thumbnail_timepoint#:#Timepoint
 upload_ui_thumbnail_timepoint_info#:#The time point of the video to extract the thumbnail from. Format: HH:MM:SS (e.g. 00:01:30 for 1 minute 30 seconds).

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -788,7 +788,8 @@ upload_ui_thumbnail_mode_sg_file#:#By uploading a file
 upload_ui_thumbnail_mode_sg_timepoint#:#By selecting a video tiempoint
 upload_ui_thumbnail_file#:#Thumbnail File
 upload_ui_thumbnail_timepoint#:#Timepoint
-upload_ui_thumbnail_timepoint_info#:#The time point of the video to extract thumbnail from.
+upload_ui_thumbnail_timepoint_info#:#The time point of the video to extract the thumbnail from. Format: HH:MM:SS (e.g. 00:01:30 for 1 minute 30 seconds).
+upload_ui_thumbnail_timepoint_invalid#:#Invalid format. Please use HH:MM:SS (e.g. 00:01:30).
 show_more#:#More
 title_asc#:#Title A-Z
 title_desc#:#Title Z-A

--- a/src/UI/EventFormBuilder.php
+++ b/src/UI/EventFormBuilder.php
@@ -267,8 +267,8 @@ class EventFormBuilder
         $wf_id = 'straightToPublishing';
         $stp_wf_value = WorkflowParameter::VALUE_ALWAYS_ACTIVE; // as default value in workflows are always true.
         $wf_title = 'Straight to publishing'; // We set a default value here to avoid confusion in lang string replacements.
-        if (WorkflowParameter::where(['id' => $wf_id])->hasSets()) {
-            $workflow_parameter = WorkflowParameter::find($wf_id);
+        $workflow_parameter = WorkflowParameter::find($wf_id);
+        if ($workflow_parameter !== null) {
             $stp_wf_value =
                 $as_admin ?
                 $workflow_parameter->getDefaultValueAdmin() :
@@ -315,78 +315,34 @@ class EventFormBuilder
                     )
                 );
 
-            // Thumbnail timepoint timepicker input.
-            $target_accept_video_files = implode(',', $this->getMimeTypes());
-            $date_default = new \DateTime('today midnight');
-            $value_format_str = $date_default->format('H:i:s');
-            $timepoint_picker = $factory->dateTime(
+            // Thumbnail timepoint input. Expects HH:MM:SS, transformed to seconds.
+            $timepoint_picker = $factory->text(
                 $this->plugin->txt('upload_ui_thumbnail_timepoint'),
                 $this->plugin->txt('upload_ui_thumbnail_timepoint_info')
             )
-                ->withValue($value_format_str)
-                ->withTimeOnly(true)
-                ->withAdditionalOnLoadCode(fn(string $id): string => '
-                    // On show: Set min date, in order to prevent infinite loop.
-                    $("#' . $id . '").on("dp.show", function () {
-                        let minDate = new Date();
-                        minDate.setHours(0,0,0,0);
-                        $("#' . $id . '").data("DateTimePicker").minDate(minDate);
-                    });
-                    // On change: reset placeholder and the date value if clear is performed.
-                    $("#' . $id . '").on("dp.change", function ({date, oldDate}) {
-                        if (!date) {
-                            // Reset placeholder on clear.
-                            $("#' . $id . '").find("input").attr("placeholder", "00:00:00");
-                            // Reset value on clear.
-                            let resetDate = new Date();
-                            resetDate.setHours(0,0,0,0);
-                            $("#' . $id . '").data("DateTimePicker").date(resetDate);
+                ->withValue('00:00:01')
+                ->withAdditionalOnLoadCode(
+                    fn(string $id): string =>
+                        "document.getElementById('$id').querySelector('input').setAttribute('placeholder', '00:00:00');"
+                )
+                ->withAdditionalTransformation(
+                    $this->refinery_factory->custom()->constraint(
+                        fn($v): bool => is_string($v)
+                            && ($v === '' || preg_match('/^\d{1,3}:[0-5]\d:[0-5]\d$/', $v) === 1),
+                        $this->plugin->txt('upload_ui_thumbnail_timepoint_invalid')
+                    )
+                )
+                ->withAdditionalTransformation(
+                    $this->refinery_factory->custom()->transformation(
+                        function (string $v): int {
+                            if ($v === '') {
+                                return 0;
+                            }
+                            [$h, $m, $s] = array_map('intval', explode(':', $v));
+                            return $h * 3600 + $m * 60 + $s;
                         }
-                    });
-                    // Extra: set max duration based on uploaded video file.
-                    window.URL = window.URL || window.webkitURL;
-                    function bindEventExtractVideoDuration() {
-                        var file_inputs = $("input:file");
-                        if (file_inputs.length > 0) {
-                            file_inputs.each(function (i, el) {
-                                if ($(el).attr("accept") == "' . $target_accept_video_files . '") {
-                                    $(el).on("change" , function () {
-                                        let files = this.files;
-                                        let video = document.createElement("video");
-                                        video.preload = "metadata";
-                                        video.onloadedmetadata = function() {
-                                            const duration = video.duration;
-                                            const hours = parseInt(Math.floor(duration / 3600), 10);
-                                            const minutes = parseInt(Math.floor((duration % 3600) / 60), 10);
-                                            const remainingSeconds = parseInt(duration % 60, 10);
-                                            // Reset date.
-                                            const resetDate = new Date();
-                                            resetDate.setHours(0,0,0,0);
-                                            $("#' . $id . '").data("DateTimePicker").date(resetDate);
-                                            // Max date,
-                                            const maxDate = new Date();
-                                            maxDate.setHours(hours,minutes,remainingSeconds,0);
-                                            $("#' . $id . '").data("DateTimePicker").maxDate(maxDate);
-                                        }
-                                        video.src = URL.createObjectURL(files[0]);
-                                    });
-                                }
-                            });
-                        }
-                    }
-                    setTimeout(function () {
-                        bindEventExtractVideoDuration();
-                        $("[data-videoFileInput]").find(".ui-input-file-input-dropzone").on("drop", function () {
-                            bindEventExtractVideoDuration();
-                        });
-                        $("[data-videoFileInput]").find(".ui-input-file-input-dropzone > button").on("click", function () {
-                            bindEventExtractVideoDuration();
-                        });
-                    }, 500);')
-                ->withAdditionalPickerconfig([
-                    'useCurrent' => false,
-                    'format' => 'HH:mm:ss',
-                ]);
+                    )
+                );
 
             if ($thumbnail_upload_mode_is_both) {
                 $file_input_group = $factory->group(


### PR DESCRIPTION
Fixes #485

## Problem
Thumbnail timepoint selection in the upload modal used a datetime picker (`H:i:s` time-only), which is confusing for picking a point inside a video. Regressed vs plugin < 9.x.

## Fix
Replace the datetime picker with a plain text input expecting `HH:MM:SS`:

- Default value `00:00:01`, placeholder `00:00:00`.
- Format help text added to the field info.
- Constraint validates `^\d{1,3}:[0-5]\d:[0-5]\d$` (empty allowed), with a dedicated error lang string `upload_ui_thumbnail_timepoint_invalid`.
- Transformation converts `HH:MM:SS` to seconds (int), consumed directly as `snapshotThumbnailTime` workflow param.
- `xoctEventGUI` consumer updated from `DateTimeImmutable` handling to the new int value.

## Files
- `src/UI/EventFormBuilder.php`
- `classes/Event/class.xoctEventGUI.php`
- `lang/ilias_de.lang`, `lang/ilias_en.lang`

Per meeting decision on the issue: textbox with constraints, `0:00:01` default, `h:mm:ss` format help.

