### PR TITLE
[FIX] My Events: include offline-state events in list

### DIFF
--- a/src/UI/Integration/MyEvents.php
+++ b/src/UI/Integration/MyEvents.php
@@ -62,6 +62,11 @@ class MyEvents implements DataRetrieval
     private ?URI $calling_url = null;
     private int $default_page_size = 20;
 
+    private array $supported_event_states = [
+        Event::STATE_SUCCEEDED,
+        Event::STATE_OFFLINE
+    ];
+
     public function __construct(
         private \ILIAS\UI\Factory $ui_factory,
         private Container $container,
@@ -287,7 +292,8 @@ class MyEvents implements DataRetrieval
         ) {
             $action = (string) $this->target_url->withParameter($this->parameter_name, $event->getIdentifier());
 
-            $is_successfully_processed = $event->getProcessingState() === Event::STATE_SUCCEEDED;
+            $processing_state = $event->getProcessingState();
+            $is_successfully_processed = in_array($processing_state, $this->supported_event_states, true);
 
             $thumbnail = $this->ui_factory->symbol()->icon()->custom(
                 $event->publications()->getThumbnailUrl(),
@@ -326,7 +332,7 @@ class MyEvents implements DataRetrieval
                     'date' => $event->getStart(),
                     'series' => $this->getSeriesName($event),
                     'presenter' => implode(", ", $event->getPresenter()),
-                    'status' => $event->getProcessingState(),
+                    'status' => $processing_state,
                     'action' => $is_successfully_processed ? $this->ui_renderer->render($select_action) : ''
                 ]
             );


### PR DESCRIPTION
## Problem
The "My Events" data retrieval only treated events with processing state `SUCCEEDED` as available — building the thumbnail/select-action only for those. Events marked offline (`STATE_OFFLINE`) were excluded, so a published-but-offline event had no thumbnail and no select action in the My Events list.

## Fix
Introduce a `supported_event_states` whitelist (`STATE_SUCCEEDED`, `STATE_OFFLINE`) and check membership instead of equality against `SUCCEEDED` only.

## Files
- `src/UI/Integration/MyEvents.php`

## Note
Split out of #514 (thumbnail duration fix) — unrelated change that was bundled in the same commit. Related to the online/offline state handling tracked in #440.