### PR TITLE
[FIX] Chunked upload fails for large files #518

### DIFF
--- a/classes/Conf/class.xoctConfFormGUI.php
+++ b/classes/Conf/class.xoctConfFormGUI.php
@@ -4,9 +4,7 @@ declare(strict_types=1);
 
 use srag\Plugins\Opencast\Model\Config\PluginConfig;
 use srag\Plugins\Opencast\Model\User\xoctUser;
-use srag\Plugins\Opencast\DI\OpencastDIC;
 use srag\Plugins\Opencast\Util\Locale\LocaleTrait;
-use srag\Plugins\Opencast\LegacyHelpers\UploadSize;
 use srag\Plugins\Opencast\Container\Init;
 
 /**
@@ -141,8 +139,6 @@ class xoctConfFormGUI extends ilPropertyFormGUI
 
     /**
      * @param $item
-     *
-     * @return bool
      */
     public static function checkItem($item): bool
     {
@@ -196,16 +192,6 @@ class xoctConfFormGUI extends ilPropertyFormGUI
         );
         $te->setInfo($this->getLocaleString(PluginConfig::F_CURL_MAX_UPLOADSIZE . '_info'));
         $te->setRequired(true);
-        $this->addItem($te);
-
-        $te = new ilNumberInputGUI(
-            $this->getLocaleString(PluginConfig::F_CURL_CHUNK_SIZE),
-            PluginConfig::F_CURL_CHUNK_SIZE
-        );
-        $te->setInfo($this->getLocaleString(PluginConfig::F_CURL_CHUNK_SIZE . '_info'));
-        $te->setRequired(true);
-        $te->setMinValue(1, true);
-        $te->setMaxValue(UploadSize::getUploadSizeLimitBytes() / 1024 / 1024 / 2, true);
         $this->addItem($te);
 
         $te = new ilTextInputGUI(

--- a/classes/Setup/class.ilOpenCastDBUpdateSteps.php
+++ b/classes/Setup/class.ilOpenCastDBUpdateSteps.php
@@ -152,4 +152,18 @@ class ilOpenCastDBUpdateSteps implements \ilDatabaseUpdateSteps
             ]
         );
     }
+
+    /**
+     * Removes the orphaned "curl_chunk_size" config. The chunk size is no longer
+     * configurable: the ILIAS UI file field decides on its own whether to chunk
+     * and fixes the chunk size at ~90% of the PHP upload limit.
+     */
+    public function step_7(): void
+    {
+        $this->db->manipulateF(
+            'DELETE FROM xoct_config WHERE name = %s',
+            ['text'],
+            ['curl_chunk_size']
+        );
+    }
 }

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -28,8 +28,6 @@ config_api_version#:#API-Version
 config_api_version_info#:#Format: vX.Y.Z - z.B.: v1.0.0
 config_curl_max_upload_size#:#Maximale Upload-Größe in MB
 config_curl_max_upload_size_info#:#Definiert die maximal mögliche Uploadgröße für Video-Dateien in MB
-config_curl_chunk_size#:#Chunk-Größe in MB
-config_curl_chunk_size_info#:#Definiert die Grösse der einzelnen Upload-Chunks in MB. Grosse Dateien werden in einzelnen Teilen (Chunks) hochgeladen. Kleinere Chunks sind besser bei langsamen Internet-Verbindungen, grössere Chunks sind besser bei schnellen Internetverbindungen.
 config_audio_allowed#:#Audio-Dateien
 config_cancel#:#Abbrechen
 config_create_scheduled_allowed#:#"Aufzeichnungstermin(e) planen" erlauben

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -28,8 +28,6 @@ config_api_version#:#API Version
 config_api_version_info#:#Format: vX.Y.Z - e.g.: v1.0.0
 config_curl_max_upload_size#:#Max. File-Size in MB
 config_curl_max_upload_size_info#:#Defines the maximum possible upload size for video files in MB
-config_curl_chunk_size#:#Chunk size in MB
-config_curl_chunk_size_info#:#Defines the size of individual upload chunks in MB. Large files are uploaded in single parts (chunks). Smaller chunks are better for slow internet connections, larger chunks are better for fast internet connections.
 config_audio_allowed#:#Audio Files
 config_cancel#:#Cancel
 config_create_scheduled_allowed#:#Activate "Schedule Event(s)"

--- a/src/Model/Config/PluginConfig.php
+++ b/src/Model/Config/PluginConfig.php
@@ -38,7 +38,6 @@ class PluginConfig extends ActiveRecord
     public const F_CURL_USERNAME = 'curl_username';
     public const F_CURL_PASSWORD = 'curl_password';
     public const F_CURL_MAX_UPLOADSIZE = 'curl_max_upload_size';
-    public const F_CURL_CHUNK_SIZE = 'curl_chunk_size';
     public const F_WORKFLOW = 'workflow';
     public const F_WORKFLOW_UNPUBLISH = 'workflow_unpublish';
     public const F_EULA = 'eula';
@@ -165,9 +164,6 @@ class PluginConfig extends ActiveRecord
         self::F_ROLE_USER_PREFIX,
         self::F_ROLE_OWNER_PREFIX
     ];
-    /**
-     * @var array
-     */
     public static array $groups = [
         self::F_GROUP_PRODUCERS,
         self::F_GROUP_STUDIO,
@@ -227,8 +223,8 @@ class PluginConfig extends ActiveRecord
             $name = $node->getElementsByTagName('name')->item(0)->nodeValue;
             $value = $node->getElementsByTagName('value')->item(0)->nodeValue;
             if ($name) {
-                $value = (is_array(json_decode($value)))
-                    ? json_decode($value)
+                $value = (is_array(json_decode((string) $value)))
+                    ? json_decode((string) $value)
                     : $value;
                 PluginConfig::set($name, $value);
             }
@@ -468,7 +464,7 @@ class PluginConfig extends ActiveRecord
         $config = $domxml->appendChild(new DOMElement('opencast_settings'));
 
         $xml_info = $config->appendChild(new DOMElement('info'));
-        $xml_info->appendChild(new DOMElement('plugin_version', (string) $opencast_plugin->getVersion()));
+        $xml_info->appendChild(new DOMElement('plugin_version', $opencast_plugin->getVersion()));
         $xml_info->appendChild(new DOMElement('plugin_db_version', (string) $plugin_infos->getCurrentDBVersion()));
         $xml_info->appendChild(
             new DOMElement('config_version', (string) PluginConfig::getConfig(PluginConfig::F_CONFIG_VERSION))

--- a/src/UI/EventFormBuilder.php
+++ b/src/UI/EventFormBuilder.php
@@ -21,7 +21,6 @@ use srag\Plugins\Opencast\Model\WorkflowParameter\Series\SeriesWorkflowParameter
 use srag\Plugins\Opencast\UI\Metadata\MDFormItemBuilder;
 use srag\Plugins\Opencast\UI\Scheduling\SchedulingFormItemBuilder;
 use srag\Plugins\Opencast\Util\FileTransfer\UploadStorageService;
-use ILIAS\UI\Implementation\Component\Input\Field\ChunkedFile;
 use srag\Plugins\Opencast\Model\Metadata\MetadataField;
 use srag\Plugins\Opencast\Model\Metadata\Definition\MDDataType;
 use DateTimeZone;
@@ -135,9 +134,9 @@ class EventFormBuilder
             ? $configured_upload_limit * self::MB_IN_B
             : self::DEFAULT_UPLOAD_LIMIT_IN_MIB * self::MB_IN_B;
 
-        // Chunk Size
-        $chunk_size = (int) PluginConfig::getConfig(PluginConfig::F_CURL_CHUNK_SIZE);
-        $chunk_size > 0 ? $chunk_size * 1024 * 1024 : \ilFileUtils::getUploadSizeLimitBytes();
+        // Note: the chunk size cannot be configured here. The ILIAS UI file
+        // field decides on its own whether to chunk (max file size > PHP limit)
+        // and fixes the chunk size at ~90% of the PHP upload limit.
 
         $file_input = $file_input->withAcceptedMimeTypes($this->getMimeTypes())
                                  ->withRequired(true)

--- a/src/Util/FileTransfer/UploadStorageService.php
+++ b/src/Util/FileTransfer/UploadStorageService.php
@@ -8,13 +8,13 @@ use ILIAS\Data\DataSize;
 use ILIAS\Filesystem\Exception\FileNotFoundException;
 use ILIAS\Filesystem\Exception\IOException;
 use ILIAS\Filesystem\Filesystem;
+use ILIAS\Filesystem\Stream\Streams;
 use ILIAS\FileUpload\DTO\UploadResult;
 use ILIAS\FileUpload\FileUpload;
 use ILIAS\FileUpload\Location;
 use srag\Plugins\Opencast\Model\ACL\ACL;
 use srag\Plugins\Opencast\Util\Transformator\ACLtoXML;
 use xoctUploadFile;
-use ILIAS\Filesystem\DTO\Metadata;
 use srag\Plugins\Opencast\Util\MimeType as MimeTypeUtil;
 
 class UploadStorageService
@@ -39,11 +39,35 @@ class UploadStorageService
     {
         $path = $this->idToDirPath($chunk_id) . '/' . $uploadResult->getName();
 
-        if ($this->fileSystem->has($path)) {
-            $stream = fopen($this->fileSystem->readStream($path)->getMetadata()['uri'], 'a');
-            fwrite($stream, file_get_contents($uploadResult->getPath()));
-        } else {
-            $this->fileSystem->write($path, file_get_contents($uploadResult->getPath()));
+        $source = fopen($uploadResult->getPath(), 'rb');
+        if ($source === false) {
+            throw new IOException('Could not open uploaded chunk for reading.');
+        }
+
+        try {
+            if ($this->fileSystem->has($path)) {
+                // Subsequent chunks: append directly to the existing file via a
+                // stream copy. file_get_contents() would load the whole chunk
+                // (up to ~90% of the PHP upload limit) into memory and exhaust
+                // memory_limit on large uploads, which broke multi-chunk uploads.
+                $target = fopen(ILIAS_DATA_DIR . '/' . CLIENT_ID . '/temp/' . $path, 'ab');
+                if ($target === false) {
+                    throw new IOException('Could not open chunk storage for appending.');
+                }
+                try {
+                    stream_copy_to_stream($source, $target);
+                } finally {
+                    fclose($target);
+                }
+            } else {
+                // First chunk: let the filesystem create the directory and the
+                // file with a memory-safe stream write.
+                $this->fileSystem->writeStream($path, Streams::ofResource($source));
+            }
+        } finally {
+            if (is_resource($source)) {
+                fclose($source);
+            }
         }
 
         return $chunk_id;
@@ -55,7 +79,7 @@ class UploadStorageService
      */
     public function delete(string $identifier): void
     {
-        if (strlen($identifier) == 0) {
+        if ($identifier === '') {
             return;
         }
         $dir = $this->idToDirPath($identifier);
@@ -143,9 +167,7 @@ class UploadStorageService
     {
         $dir = $this->idToDirPath($identifier);
         foreach ($this->fileSystem->finder()->in([$dir]) as $file) {
-            if($file instanceof Metadata) {
-                return $file;
-            }
+            return $file;
         }
         throw new FileNotFoundException();
     }


### PR DESCRIPTION
Fixes #518

## Problem
Uploading videos larger than ~270 MiB (≈90 % of the PHP upload limit) failed with an error page:

```
ILIAS\Filesystem\Exception\FileNotFoundException
  at UploadStorageService.php:150 (idToFileMetadata)
```

Smaller files uploaded fine, ILIAS 9 / release_9 were unaffected.

## Root cause
The ILIAS 10 UI file field auto-enables chunked uploads only when the configured max file size exceeds the PHP upload limit, and fixes the chunk size at `0.9 × php_upload_limit` (~270 MiB at `post_max_size = 300M`).

- Files below one chunk → single `write()` → worked.
- Files above one chunk → `appendChunkToStorage()` (the **append** path) → broke. The threshold matches the reported boundary exactly.

`appendChunkToStorage()` was unsafe:
- `file_get_contents()` loaded each ~270 MiB chunk fully into memory → `memory_limit` pressure on large uploads.
- It relied on `readStream()->getMetadata()['uri']`, which is fragile under **Flysystem 3** (new in ILIAS 10; release_9 used Flysystem 1).
- The append file handle was never closed.

## Fix
- Rewrite `appendChunkToStorage()` as a **memory-safe stream copy**: first chunk via `writeStream()`, subsequent chunks appended with `stream_copy_to_stream()`; all handles closed.
- Remove the **non-functional "chunk size" configuration** (`F_CURL_CHUNK_SIZE`): the UI file field controls chunking itself and the value was never passed to the field (dead code in `EventFormBuilder`), which is why tuning 5/50/100 MB had no effect. Field, constant and language strings removed; the orphaned `xoct_config` row is dropped via `ilOpenCastDBUpdateSteps::step_7()`.

## Note
Could not run a live ILIAS instance to reproduce; the fix is derived from the code path and the chunk-size threshold matching the report. Please test with a file > ~270 MiB against the customer's `post_max_size` / `memory_limit`.