### PR TITLE
[FIX] Series event list: honor the default sort (newest first) #496

### DIFF
--- a/src/UI/Integration/Series.php
+++ b/src/UI/Integration/Series.php
@@ -256,7 +256,7 @@ class Series implements DataRetrieval
                     ->viewControl()
                     ->sortation(
                         $sortation_options,
-                        $this->resolver->resolveParameter(SeriesActionParameter::SORT) ?? self::SORT_DATE_DESC
+                        $this->resolver->resolveParameter(SeriesActionParameter::SORT) ?? self::DEFAULT_SORT
                     )
                     ->withTargetURL(
                         (string) $this->resolver->resolve(SeriesActionTarget::SORT),
@@ -269,7 +269,7 @@ class Series implements DataRetrieval
     public function getEntities(Mapping $mapping, ?Range $range, ?array $additional_parameters): \Generator
     {
         $page = $this->resolver->resolveParameter(SeriesActionParameter::PAGE);
-        $sort = $this->resolver->resolveParameter(SeriesActionParameter::SORT) ?? self::SORT_DATE_ASC;
+        $sort = $this->resolver->resolveParameter(SeriesActionParameter::SORT) ?? self::DEFAULT_SORT;
 
         $api_sort = match ($sort) {
             self::SORT_OWNER_ASC, self::SORT_OWNER_DESC => '', // we cannot sort by owner via API


### PR DESCRIPTION
The sortation view control defaulted to `date:desc` ("Neueste zuerst") while `getEntities()` fetched events with a `date:asc` fallback when no sort parameter was set. The initial list was therefore ascending although the control showed descending. Both now use the `DEFAULT_SORT` constant so the displayed default and the fetched order match.

Fixes opencast-ilias/OpenCast#496

Note: the secondary request in the issue (persist sort/pagination across sessions) is out of scope for this fix.