### PR TITLE
[FEATURE] Remember series list sort and page size per user #496

### DIFF
--- a/src/State/ScopedSettingsStore.php
+++ b/src/State/ScopedSettingsStore.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace srag\Plugins\Opencast\State;
+
+/**
+ * Persists small, per-user UI state (e.g. a chosen sort order or page size)
+ * under an arbitrary scope.
+ *
+ * The store is implicitly scoped to the current user: the implementation decides
+ * how that scoping is realised (the ILIAS session is already per-user; a future
+ * database-backed implementation would include the user id). Keeping the user
+ * out of this interface lets us swap the backing storage without touching any
+ * consumer.
+ *
+ * The $scope groups values that belong together (e.g. one Opencast object /
+ * table); $key identifies the individual setting within that scope.
+ *
+ * @author Fabian Schmid <fabian@sr.solutions>
+ */
+interface ScopedSettingsStore
+{
+    public function get(string $scope, string $key): ?string;
+
+    public function set(string $scope, string $key, string $value): void;
+
+    public function remove(string $scope, string $key): void;
+}

--- a/src/State/SessionSettingsStore.php
+++ b/src/State/SessionSettingsStore.php
@@ -36,6 +36,10 @@ final class SessionSettingsStore implements ScopedSettingsStore
     public function remove(string $scope, string $key): void
     {
         $all = $this->all();
+        if (!isset($all[$scope][$key])) {
+            return;
+        }
+
         unset($all[$scope][$key]);
         ilSession::set(self::SESSION_KEY, $all);
     }

--- a/src/State/SessionSettingsStore.php
+++ b/src/State/SessionSettingsStore.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace srag\Plugins\Opencast\State;
+
+use ilSession;
+
+/**
+ * Session-backed {@see ScopedSettingsStore}. This is the only place that touches
+ * ilSession, so the backing storage can be replaced without affecting consumers.
+ *
+ * The ILIAS session is already per-user, which gives us the per-user scoping for
+ * free. All values live under a single session key as a nested array
+ * (scope => key => value), which ilSession serialises into the DB session.
+ *
+ * @author Fabian Schmid <fabian@sr.solutions>
+ */
+final class SessionSettingsStore implements ScopedSettingsStore
+{
+    private const SESSION_KEY = 'xoct_ui_settings';
+
+    public function get(string $scope, string $key): ?string
+    {
+        $value = $this->all()[$scope][$key] ?? null;
+        return is_string($value) ? $value : null;
+    }
+
+    public function set(string $scope, string $key, string $value): void
+    {
+        $all = $this->all();
+        $all[$scope][$key] = $value;
+        ilSession::set(self::SESSION_KEY, $all);
+    }
+
+    public function remove(string $scope, string $key): void
+    {
+        $all = $this->all();
+        unset($all[$scope][$key]);
+        ilSession::set(self::SESSION_KEY, $all);
+    }
+
+    /**
+     * @return array<string, array<string, string>>
+     */
+    private function all(): array
+    {
+        $all = ilSession::get(self::SESSION_KEY);
+        return is_array($all) ? $all : [];
+    }
+}

--- a/src/UI/Integration/Integration.php
+++ b/src/UI/Integration/Integration.php
@@ -12,6 +12,7 @@ use srag\Plugins\Opencast\Views\Series\EventSettingsResolver;
 use srag\Plugins\Opencast\UI\Integration\Event\EventSettingsValueResolver;
 use srag\Plugins\Opencast\UI\Integration\Event\EventActionTargetResolver;
 use srag\Plugins\Opencast\UI\Integration\Series\SeriesActionTargetResolver;
+use srag\Plugins\Opencast\State\SessionSettingsStore;
 
 /**
  * @author Fabian Schmid <fabian@sr.solutions>
@@ -63,7 +64,8 @@ class Integration
             $series_action_target_resolver ?? new SeriesActionResolver(
                 $container->translator(),
                 $container->ilias()->http(),
-                $container->ilias()->ctrl()
+                $container->ilias()->ctrl(),
+                new SessionSettingsStore()
             ),
             $settings_resolver
         );

--- a/src/UI/Integration/Series.php
+++ b/src/UI/Integration/Series.php
@@ -187,6 +187,10 @@ class Series implements DataRetrieval
     ): \Generator {
         $this->buildSeries($series_id);
 
+        $table_id = $this->series->getIdentifier();
+        $page_size = (int) ($this->resolver->resolvePersistentParameter(SeriesActionParameter::PAGE_SIZE, $table_id) ?? self::DEFAULT_PAGE_SIZE);
+        $sort = $this->resolver->resolvePersistentParameter(SeriesActionParameter::SORT, $table_id) ?? self::DEFAULT_SORT;
+
         $entity_list = iterator_to_array($this->asEntityList($series_id));
 
         $sortation_options = [
@@ -224,9 +228,7 @@ class Series implements DataRetrieval
                     ->viewControl()
                     ->pagination()
                     ->withCurrentPage($this->resolver->resolveParameter(SeriesActionParameter::PAGE))
-                    ->withPageSize(
-                        $this->resolver->resolveParameter(SeriesActionParameter::PAGE_SIZE) ?? self::DEFAULT_PAGE_SIZE
-                    )
+                    ->withPageSize($page_size)
                     ->withMaxPaginationButtons(5)
                     ->withTotalEntries($this->total)
                     ->withTargetURL(
@@ -242,9 +244,7 @@ class Series implements DataRetrieval
                             '20' => '20',
                             '50' => '50',
                         ],
-                        (string) ($this->resolver->resolveParameter(
-                            SeriesActionParameter::PAGE_SIZE
-                        ) ?? self::DEFAULT_PAGE_SIZE)
+                        (string) $page_size
                     )
                     ->withLabelPrefix('')
                     ->withTargetURL(
@@ -256,7 +256,7 @@ class Series implements DataRetrieval
                     ->viewControl()
                     ->sortation(
                         $sortation_options,
-                        $this->resolver->resolveParameter(SeriesActionParameter::SORT) ?? self::DEFAULT_SORT
+                        $sort
                     )
                     ->withTargetURL(
                         (string) $this->resolver->resolve(SeriesActionTarget::SORT),
@@ -268,9 +268,10 @@ class Series implements DataRetrieval
 
     public function getEntities(Mapping $mapping, ?Range $range, ?array $additional_parameters): \Generator
     {
+        $table_id = $this->series->getIdentifier();
         $page = $this->resolver->resolveParameter(SeriesActionParameter::PAGE);
-        $page_size = (int) ($this->resolver->resolveParameter(SeriesActionParameter::PAGE_SIZE) ?? self::DEFAULT_PAGE_SIZE);
-        $sort = $this->resolver->resolveParameter(SeriesActionParameter::SORT) ?? self::DEFAULT_SORT;
+        $page_size = (int) ($this->resolver->resolvePersistentParameter(SeriesActionParameter::PAGE_SIZE, $table_id) ?? self::DEFAULT_PAGE_SIZE);
+        $sort = $this->resolver->resolvePersistentParameter(SeriesActionParameter::SORT, $table_id) ?? self::DEFAULT_SORT;
 
         $api_sort = match ($sort) {
             self::SORT_OWNER_ASC, self::SORT_OWNER_DESC => '', // we cannot sort by owner via API

--- a/src/UI/Integration/Series.php
+++ b/src/UI/Integration/Series.php
@@ -269,7 +269,7 @@ class Series implements DataRetrieval
     public function getEntities(Mapping $mapping, ?Range $range, ?array $additional_parameters): \Generator
     {
         $table_id = $this->series->getIdentifier();
-        $page = $this->resolver->resolveParameter(SeriesActionParameter::PAGE);
+        $page = (int) $this->resolver->resolveParameter(SeriesActionParameter::PAGE);
         $page_size = (int) ($this->resolver->resolvePersistentParameter(SeriesActionParameter::PAGE_SIZE, $table_id) ?? self::DEFAULT_PAGE_SIZE);
         $sort = $this->resolver->resolvePersistentParameter(SeriesActionParameter::SORT, $table_id) ?? self::DEFAULT_SORT;
 

--- a/src/UI/Integration/Series/NullSeriesActionResolver.php
+++ b/src/UI/Integration/Series/NullSeriesActionResolver.php
@@ -27,4 +27,9 @@ class NullSeriesActionResolver implements SeriesActionTargetResolver
         return null;
     }
 
+    public function resolvePersistentParameter(SeriesActionParameter $parameter, string $scope): mixed
+    {
+        return null;
+    }
+
 }

--- a/src/UI/Integration/Series/SeriesActionTargetResolver.php
+++ b/src/UI/Integration/Series/SeriesActionTargetResolver.php
@@ -18,4 +18,11 @@ interface SeriesActionTargetResolver
 
     public function resolveParameter(SeriesActionParameter $parameter): mixed;
 
+    /**
+     * Like {@see resolveParameter()}, but remembers the value per user under the
+     * given scope (e.g. the series id): an explicit request value is stored and
+     * restored on later requests.
+     */
+    public function resolvePersistentParameter(SeriesActionParameter $parameter, string $scope): mixed;
+
 }

--- a/src/UI/Integration/Series/SeriesActionTargetResolver.php
+++ b/src/UI/Integration/Series/SeriesActionTargetResolver.php
@@ -22,6 +22,10 @@ interface SeriesActionTargetResolver
      * Like {@see resolveParameter()}, but remembers the value per user under the
      * given scope (e.g. the series id): an explicit request value is stored and
      * restored on later requests.
+     *
+     * @param SeriesActionParameter $parameter the parameter to resolve
+     * @param string                $scope     groups the stored values, e.g. the series id of the table
+     * @return mixed the resolved value, null when neither the request nor the store holds one
      */
     public function resolvePersistentParameter(SeriesActionParameter $parameter, string $scope): mixed;
 

--- a/src/Views/BaseActionResolver.php
+++ b/src/Views/BaseActionResolver.php
@@ -9,6 +9,7 @@ use srag\Plugins\Opencast\UI\Integration\Action;
 use srag\Plugins\Opencast\Util\Locale\Translator;
 use srag\Plugins\Opencast\UI\Integration\ActionType;
 use srag\Plugins\Opencast\UI\MakeURI;
+use srag\Plugins\Opencast\State\ScopedSettingsStore;
 
 /**
  * @author Fabian Schmid <fabian@sr.solutions>
@@ -20,8 +21,34 @@ abstract class BaseActionResolver
     public function __construct(
         protected Translator $translator,
         protected Services $http,
-        protected \ilCtrlInterface $ctrl
+        protected \ilCtrlInterface $ctrl,
+        protected ?ScopedSettingsStore $settings_store = null
     ) {
+    }
+
+    /**
+     * Resolves a value that should be remembered per user under the given scope:
+     * an explicit request value is persisted and returned; otherwise the last
+     * persisted value is returned (null if there is none and the caller applies
+     * its own default).
+     *
+     * The $scope is supplied by the caller (e.g. the series id of the table), so
+     * the resolver does not need to know how the consumer identifies itself.
+     * No-op pass-through when no store is configured, so resolvers can opt in
+     * simply by being constructed with a store.
+     */
+    protected function persisted(string $scope, string $key, ?string $raw): ?string
+    {
+        if ($this->settings_store === null) {
+            return $raw;
+        }
+
+        if ($raw !== null) {
+            $this->settings_store->set($scope, $key, $raw);
+            return $raw;
+        }
+
+        return $this->settings_store->get($scope, $key);
     }
 
     protected function build(

--- a/src/Views/BaseActionResolver.php
+++ b/src/Views/BaseActionResolver.php
@@ -36,6 +36,11 @@ abstract class BaseActionResolver
      * the resolver does not need to know how the consumer identifies itself.
      * No-op pass-through when no store is configured, so resolvers can opt in
      * simply by being constructed with a store.
+     *
+     * @param string      $scope group the value belongs to, e.g. the series id of the table
+     * @param string      $key   identifies the setting within the scope
+     * @param string|null $raw   explicit request value, null when the request carries none
+     * @return string|null the persisted value, or null when nothing has been stored yet
      */
     protected function persisted(string $scope, string $key, ?string $raw): ?string
     {

--- a/src/Views/Series/SeriesActionResolver.php
+++ b/src/Views/Series/SeriesActionResolver.php
@@ -12,6 +12,7 @@ use srag\Plugins\Opencast\UI\Integration\Series\SeriesActionParameters;
 use srag\Plugins\Opencast\UI\Integration\Series\SeriesActionParameter;
 use srag\Plugins\Opencast\Util\Locale\Translator;
 use srag\Plugins\Opencast\Model\Series\Series;
+use srag\Plugins\Opencast\State\ScopedSettingsStore;
 
 /**
  * @author Fabian Schmid <fabian@sr.solutions>
@@ -23,9 +24,10 @@ class SeriesActionResolver extends BaseActionResolver implements SeriesActionTar
     public function __construct(
         Translator $translator,
         Services $http,
-        \ilCtrlInterface $ctrl
+        \ilCtrlInterface $ctrl,
+        ?ScopedSettingsStore $settings_store = null
     ) {
-        parent::__construct($translator, $http, $ctrl);
+        parent::__construct($translator, $http, $ctrl, $settings_store);
         // funny it's xoctEventGUI as well here, but we leave it like this for now
         $this->current_url = $this->build('lorem', \xoctEventGUI::class)->target();
     }
@@ -55,6 +57,17 @@ class SeriesActionResolver extends BaseActionResolver implements SeriesActionTar
             SeriesActionParameter::PAGE_SIZE => (int) ($this->http->request()->getQueryParams()[$parameter->value] ?? \srag\Plugins\Opencast\UI\Integration\Series::DEFAULT_PAGE_SIZE),
             default => $this->http->request()->getQueryParams()[$parameter->value] ?? null,
         };
+    }
+
+    public function resolvePersistentParameter(SeriesActionParameter $parameter, string $scope): mixed
+    {
+        // Remember an explicit request value and restore it on later requests;
+        // when nothing has been stored yet, fall back to the normal resolution.
+        // The caller is responsible for casting/defaulting the (possibly null) result.
+        $raw = $this->http->request()->getQueryParams()[$parameter->value] ?? null;
+        $stored = $this->persisted($scope, $parameter->value, is_scalar($raw) ? (string) $raw : null);
+
+        return $stored ?? $this->resolveParameter($parameter);
     }
 
 }

--- a/vendor/composer/autoload_classmap.php
+++ b/vendor/composer/autoload_classmap.php
@@ -260,6 +260,8 @@ return array(
     'srag\\Plugins\\Opencast\\Model\\Workflow\\WorkflowRepository' => $baseDir . '/src/Model/Workflow/WorkflowRepository.php',
     'srag\\Plugins\\Opencast\\Notification\\DefaultNotificationSender' => $baseDir . '/src/Notification/DefaultNotificationSender.php',
     'srag\\Plugins\\Opencast\\Notification\\NotificationSender' => $baseDir . '/src/Notification/NotificationSender.php',
+    'srag\\Plugins\\Opencast\\State\\ScopedSettingsStore' => $baseDir . '/src/State/ScopedSettingsStore.php',
+    'srag\\Plugins\\Opencast\\State\\SessionSettingsStore' => $baseDir . '/src/State/SessionSettingsStore.php',
     'srag\\Plugins\\Opencast\\UI\\EventFormBuilder' => $baseDir . '/src/UI/EventFormBuilder.php',
     'srag\\Plugins\\Opencast\\UI\\EventTableBuilder' => $baseDir . '/src/UI/EventTableBuilder.php',
     'srag\\Plugins\\Opencast\\UI\\Integration\\Action' => $baseDir . '/src/UI/Integration/Action.php',

--- a/vendor/composer/autoload_static.php
+++ b/vendor/composer/autoload_static.php
@@ -350,6 +350,8 @@ class ComposerStaticInit20975cba620fc47d8c392214bb856b0a
         'srag\\Plugins\\Opencast\\Model\\Workflow\\WorkflowRepository' => __DIR__ . '/../..' . '/src/Model/Workflow/WorkflowRepository.php',
         'srag\\Plugins\\Opencast\\Notification\\DefaultNotificationSender' => __DIR__ . '/../..' . '/src/Notification/DefaultNotificationSender.php',
         'srag\\Plugins\\Opencast\\Notification\\NotificationSender' => __DIR__ . '/../..' . '/src/Notification/NotificationSender.php',
+        'srag\\Plugins\\Opencast\\State\\ScopedSettingsStore' => __DIR__ . '/../..' . '/src/State/ScopedSettingsStore.php',
+        'srag\\Plugins\\Opencast\\State\\SessionSettingsStore' => __DIR__ . '/../..' . '/src/State/SessionSettingsStore.php',
         'srag\\Plugins\\Opencast\\UI\\EventFormBuilder' => __DIR__ . '/../..' . '/src/UI/EventFormBuilder.php',
         'srag\\Plugins\\Opencast\\UI\\EventTableBuilder' => __DIR__ . '/../..' . '/src/UI/EventTableBuilder.php',
         'srag\\Plugins\\Opencast\\UI\\Integration\\Action' => __DIR__ . '/../..' . '/src/UI/Integration/Action.php',


### PR DESCRIPTION
Follow-up to #534 (stacks on it). Implements the secondary request in opencast-ilias/OpenCast#496: the chosen sort order and page size of the series event list are now remembered per user and per table (series), instead of being lost when navigating away.

Persistence is handled by the action resolver via a new explicit `resolvePersistentParameter($parameter, $scope)` method: an explicit request value is stored under the given scope (the series id, passed by the table) and restored on later requests; when nothing is stored it falls back to the normal `resolveParameter()`, and the caller casts/defaults the result. Storage sits behind a small `ScopedSettingsStore` interface with a session-backed implementation as the only place touching `ilSession`, so it can later be swapped for a DB/user-preference backed store without changing any consumer.

The page size is now also applied to the event fetch, so a remembered page size actually takes effect.

Refs opencast-ilias/OpenCast#496