### PR TITLE
[FIX] Restore the annotation action in the new event list #531

### DIFF
--- a/src/UI/Integration/Event/EventActionTarget.php
+++ b/src/UI/Integration/Event/EventActionTarget.php
@@ -22,5 +22,6 @@ enum EventActionTarget: string
     case GRANT_ACCESS = 'grant_access';
     case EDIT_OWNER = 'edit_owner';
     case REPUBLISH = 'republish';
+    case ANNOTATE = 'annotate';
 
 }

--- a/src/UI/Integration/Event/EventSettings.php
+++ b/src/UI/Integration/Event/EventSettings.php
@@ -18,5 +18,6 @@ enum EventSettings: string
     case DESCRIPTION_MAX_LENGTH = 'description_max_length';
     case STATUS_MAX_LENGTH = 'status_max_length';
     case EDIT_ALL_METADATA = 'edit_all_metadata';
+    case USE_ANNOTATIONS = 'use_annotations';
 
 }

--- a/src/Views/Event/EventActionResolver.php
+++ b/src/Views/Event/EventActionResolver.php
@@ -196,6 +196,13 @@ class EventActionResolver extends BaseActionResolver implements EventActionTarge
                     \xoctEventGUI::CMD_START_WORKFLOW_MODAL,
                     ActionType::ASYNC_MODAL
                 );
+            case EventActionTarget::ANNOTATE:
+                return $this->build(
+                    $this->translator->translate('event_annotate'),
+                    \xoctEventGUI::class,
+                    \xoctEventGUI::CMD_ANNOTATE,
+                    ActionType::EXTERNAL_LINK
+                );
             case EventActionTarget::REPUBLISH: // TODO Modals needed, class.xoctEventRenderer.php:673
             default:
                 return null;
@@ -283,6 +290,10 @@ class EventActionResolver extends BaseActionResolver implements EventActionTarge
                     \ilObjOpenCastAccess::ACTION_DOWNLOAD_EVENT,
                     $event
                 );
+            case EventActionTarget::ANNOTATE:
+                return (bool) $settings?->resolve(EventSettings::USE_ANNOTATIONS)
+                    && $event->getProcessingState() === Event::STATE_SUCCEEDED
+                    && (bool) $event->publications()->getAnnotationPublication();
             default:
                 return false;
 

--- a/src/Views/Event/EventSettingsResolver.php
+++ b/src/Views/Event/EventSettingsResolver.php
@@ -18,6 +18,7 @@ class EventSettingsResolver implements EventSettingsValueResolver
     private bool $player_in_modal;
     private bool $show_best_action = true; // TODO make configurable
     private bool $edit_all_metadata;
+    private bool $use_annotations;
 
     public function __construct(
         ObjectSettings $object_settings
@@ -29,6 +30,7 @@ class EventSettingsResolver implements EventSettingsValueResolver
         $this->edit_all_metadata = ((int) PluginConfig::getConfig(
             PluginConfig::F_SCHEDULED_METADATA_EDITABLE
         )) === PluginConfig::ALL_METADATA;
+        $this->use_annotations = (bool) $object_settings->getUseAnnotations();
     }
 
     public function resolve(EventSettings $setting): mixed
@@ -40,6 +42,7 @@ class EventSettingsResolver implements EventSettingsValueResolver
             EventSettings::DESCRIPTION_MAX_LENGTH => 120,
             EventSettings::STATUS_MAX_LENGTH => 80,
             EventSettings::SHOW_OWNER => $this->permission_per_clip,
+            EventSettings::USE_ANNOTATIONS => $this->use_annotations,
             EventSettings::PRESENTED_METADATA => [
                 EventSettingsValueResolver::MD_OWNER,
                 EventSettingsValueResolver::MD_LOCATION,


### PR DESCRIPTION
The redesigned (ILIAS 10) event list builds its per-event actions from the `EventActionTarget` enum, which had no case for the annotation tool. So even with 'Activate Annotations' enabled in the series settings, no action to open a video in the annotation tool was offered in the Content tab.

This adds an `ANNOTATE` action linking to `xoctEventGUI::CMD_ANNOTATE` (which redirects to the annotation tool URL), shown when the series has annotations enabled, the event is successfully processed and an annotation publication exists - mirroring the gating of the legacy table.

This covers the first part of the issue (the action is back in the event dropdown). A configurable, more prominent placement (e.g. near title/thumbnail) will follow separately.

Refs opencast-ilias/OpenCast#531