### PR TITLE
[FIX] Config table check/cross icons missing in ILIAS 10 #530

### DIFF
--- a/classes/Conf/PermissionTemplates/class.xoctPermissionTemplateTableGUI.php
+++ b/classes/Conf/PermissionTemplates/class.xoctPermissionTemplateTableGUI.php
@@ -84,10 +84,22 @@ class xoctPermissionTemplateTableGUI extends ilTable2GUI
         $a_set['title'] = $this->user->getLanguage() === 'de' ? $a_set['title_de'] : $a_set['title_en'];
         $a_set['info'] = $this->user->getLanguage() === 'de' ? $a_set['info_de'] : $a_set['info_en'];
         $a_set['actions'] = $this->buildActions($a_set);
-        $a_set['default'] = $a_set['is_default'] ? 'ok' : 'not_ok';
-        $a_set['read'] = $a_set['read_access'] ? 'ok' : 'not_ok';
-        $a_set['write'] = $a_set['write_access'] ? 'ok' : 'not_ok';
+        $a_set['default'] = $this->boolIconSrc((bool) $a_set['is_default']);
+        $a_set['read'] = $this->boolIconSrc((bool) $a_set['read_access']);
+        $a_set['write'] = $this->boolIconSrc((bool) $a_set['write_access']);
         parent::fillRow($a_set);
+    }
+
+    /**
+     * Resolves the check-/cross-icon path via the ILIAS asset resolver instead
+     * of a hard-coded template path (the standard images moved from
+     * templates/default/images to assets/images in ILIAS 10).
+     */
+    private function boolIconSrc(bool $value): string
+    {
+        return ilUtil::getHtmlPath(
+            ilUtil::getImagePath($value ? 'standard/icon_ok.svg' : 'standard/icon_not_ok.svg')
+        );
     }
 
     protected function buildActions(array $a_set): string

--- a/src/UI/Metadata/Config/MDConfigTable.php
+++ b/src/UI/Metadata/Config/MDConfigTable.php
@@ -76,9 +76,21 @@ class MDConfigTable extends ilTable2GUI
     protected function fillRow(/*array*/ array $a_set): void
     {
         $a_set['actions'] = $this->buildActions($a_set);
-        $a_set['required'] = $a_set['required'] ? 'ok' : 'not_ok';
-        $a_set['read_only'] = $a_set['read_only'] ? 'ok' : 'not_ok';
+        $a_set['required'] = $this->boolIconSrc((bool) $a_set['required']);
+        $a_set['read_only'] = $this->boolIconSrc((bool) $a_set['read_only']);
         parent::fillRow($a_set);
+    }
+
+    /**
+     * Resolves the check-/cross-icon path via the ILIAS asset resolver instead
+     * of a hard-coded template path (the standard images moved from
+     * templates/default/images to assets/images in ILIAS 10).
+     */
+    private function boolIconSrc(bool $value): string
+    {
+        return \ilUtil::getHtmlPath(
+            \ilUtil::getImagePath($value ? 'standard/icon_ok.svg' : 'standard/icon_not_ok.svg')
+        );
     }
 
     protected function buildActions(array $a_set): string

--- a/templates/default/tpl.md_config.html
+++ b/templates/default/tpl.md_config.html
@@ -15,10 +15,10 @@
 		{VAL_VISIBLE_FOR_PERMISSIONS}
 	</td>
 	<td class="std small">
-		<img width="25px" src="./templates/default/images/standard/icon_{VAL_REQUIRED}.svg">
+		<img width="25px" src="{VAL_REQUIRED}">
 	</td>
 	<td class="std small">
-		<img width="25px" src="./templates/default/images/standard/icon_{VAL_READ_ONLY}.svg">
+		<img width="25px" src="{VAL_READ_ONLY}">
 	</td>
 	<td class="std small">
 		{VAL_PREFILL}

--- a/templates/default/tpl.permission_templates.html
+++ b/templates/default/tpl.permission_templates.html
@@ -3,7 +3,7 @@
 		<span class="glyphicon glyphicon-resize-vertical"></span>
 	</td>
 	<td class="std small center">
-		<img width="25px" src="./templates/default/images/standard/icon_{VAL_DEFAULT}.svg">
+		<img width="25px" src="{VAL_DEFAULT}">
 	</td>
 	<td class="std small">
 		{VAL_TITLE}
@@ -15,10 +15,10 @@
 		{VAL_ROLE}
 	</td>
 	<td class="std small center">
-		<img width="25px" src="./templates/default/images/standard/icon_{VAL_READ}.svg">
+		<img width="25px" src="{VAL_READ}">
 	</td>
 	<td class="std small center">
-		<img width="25px" src="./templates/default/images/standard/icon_{VAL_WRITE}.svg">
+		<img width="25px" src="{VAL_WRITE}">
 	</td>
 	<td class="std small">
 		{VAL_ADDITIONAL_ACL_ACTIONS}


### PR DESCRIPTION
In several configuration subtabs (Metadata → Events/Series, Videoportal → Permission Templates) the check-/cross-icons were not displayed.

The row templates referenced the icons with a hard-coded relative path `./templates/default/images/standard/icon_*.svg`. In ILIAS 10 the standard images moved from `templates/default/images` to `assets/images`, so that path no longer resolved and the icons appeared broken.

The icon path is now built via `ilUtil::getImagePath()`/`getHtmlPath()` (version-agnostic, the same approach the workflow table already uses) and injected into the row templates.

Refs opencast-ilias/OpenCast#530