### PR TITLE
[FIX] Event upload fails when the optional thumbnail file is empty #536

### DIFF
--- a/src/UI/EventFormBuilder.php
+++ b/src/UI/EventFormBuilder.php
@@ -306,10 +306,14 @@ class EventFormBuilder
                 ->withAdditionalTransformation(
                     $this->refinery_factory->custom()->transformation(
                         function ($file) use ($upload_storage_service): array {
-                            if ($file === []) {
+                            // Optional file field: an untouched input yields an empty
+                            // id ([], [null] or ['']). getFileInfo('') would scan the
+                            // whole temp dir and return an unrelated directory, breaking
+                            // the upload (see #536). Skip when no file was selected.
+                            $id = (is_array($file) ? ($file[0] ?? '') : '') ?? '';
+                            if ($id === '') {
                                 return [];
                             }
-                            $id = $file[0] ?? '';
                             return $upload_storage_service->getFileInfo($id);
                         }
                     )

--- a/src/Util/FileTransfer/UploadStorageService.php
+++ b/src/Util/FileTransfer/UploadStorageService.php
@@ -123,6 +123,12 @@ class UploadStorageService
      */
     public function getFileInfo(string $identifier, int $fileSizeUnit = DataSize::Byte): array
     {
+        // An empty identifier would resolve to the temp root (opencast/) and
+        // return an arbitrary, unrelated upload directory, which then breaks the
+        // mime-type lookup (see #535, #536). Refuse it explicitly.
+        if ($identifier === '') {
+            throw new FileNotFoundException('Empty upload identifier.');
+        }
         $metadata = $this->idToFileMetadata($identifier);
         /** TODO: path is hard coded here because it's required to send the file via curlFile and I didn't find a way to get the path dynamically from the file service */
         try {
@@ -166,7 +172,9 @@ class UploadStorageService
     protected function idToFileMetadata(string $identifier)
     {
         $dir = $this->idToDirPath($identifier);
-        foreach ($this->fileSystem->finder()->in([$dir]) as $file) {
+        // Restrict to files: a bare directory would be passed on to
+        // getMimeType() and fail with a misleading "file not found" (see #536).
+        foreach ($this->fileSystem->finder()->in([$dir])->files() as $file) {
             return $file;
         }
         throw new FileNotFoundException();


### PR DESCRIPTION
Fixes #536. An empty optional thumbnail file field sent an empty upload id, so getFileInfo scanned the temp root, returned an unrelated directory and aborted the event upload with a file-not-found error.
