### PR TITLE
[FIX] Start workflow queries all events instead of one #541

### DIFF
--- a/src/UI/Modal/EventModals.php
+++ b/src/UI/Modal/EventModals.php
@@ -62,6 +62,11 @@ class EventModals
 
             $tpl->setVariable('FORM_SUBMIT_BTN_ID', $form_submit_btn_id);
             $tpl->setVariable('FORM_ID', $form_id);
+            // Bake the event id into the hidden field server-side. Relying on JS to
+            // inject it on modal click is racy: the submit handler fires before the
+            // click bubbles up, so the field stayed empty and startWorkflow() queried
+            // GET /api/events/ (all events) instead of a single event (see #541).
+            $tpl->setVariable('EVENT_ID', $event_id);
             $tpl->setVariable(
                 'FORM_ACTION',
                 $this->dic->ctrl()->getFormAction($this->parent_gui, $this->parent_gui::CMD_START_WORKFLOW)
@@ -152,8 +157,7 @@ class EventModals
             $modal_startworkflow = $this->dic->ui()->factory()->modal()->roundtrip(
                 $this->plugin->txt('event_startworkflow'),
                 $this->dic->ui()->factory()->legacy($tpl->get())
-            )->withActionButtons([$submit_btn])
-            ->withOnLoadCode(fn($id): string => "$($id).on('click', function(event){ $('input#startworkflow_event_id').val('{$event_id}');});");
+            )->withActionButtons([$submit_btn]);
             $this->setStartworkflowModal($modal_startworkflow);
         }
     }

--- a/templates/default/tpl.startworkflow_modal.html
+++ b/templates/default/tpl.startworkflow_modal.html
@@ -3,7 +3,7 @@
 	<span class="hidden" id="required">{CONFIG_PANEL_REQUIRED_ERROR_TEXT}</span>
 </div>
 <form id="{FORM_ID}" role="form" action="{FORM_ACTION}" method="post" class="form-horizontal preventDoubleSubmission startworkflow-form" novalidate="novalidate">
-	<input type="hidden" name="startworkflow_event_id" id="startworkflow_event_id" value="">
+	<input type="hidden" name="startworkflow_event_id" id="startworkflow_event_id" value="{EVENT_ID}">
 	<div class="form-horizontal">
 		<div class="form-group" id="workflow_id_block">
 			<label for="workflow_id" class="col-sm-4 wf-labels">Workflow</label>


### PR DESCRIPTION
Fixes #541. Starting a workflow for a single event queried GET /api/events/ (all events) because the modal event id was injected too late by JS. The event id is now baked into the hidden field server-side.
