### PR TITLE
[FIX] Scheduled events: keep date and recording station read-only #545

### DIFF
--- a/src/Views/Event/EventActionResolver.php
+++ b/src/Views/Event/EventActionResolver.php
@@ -125,12 +125,17 @@ class EventActionResolver extends BaseActionResolver implements EventActionTarge
                 );
 
             case EventActionTarget::EDIT_METADATA:
-                if (
-                    $event->isScheduled()
-                    && (bool) $settings?->resolve(EventSettings::EDIT_ALL_METADATA)
-                ) {
+                if ($event->isScheduled()) {
+                    // A scheduled event always goes to the scheduled form: it is the only
+                    // one that keeps date and recording station out of the metadata section
+                    // and disables the scheduling section unless all metadata is editable.
+                    // The setting merely picks the label (see #545).
                     return $this->build(
-                        $this->translator->translate('event_edit_date'),
+                        $this->translator->translate(
+                            (bool) $settings?->resolve(EventSettings::EDIT_ALL_METADATA)
+                                ? 'event_edit_date'
+                                : 'event_edit'
+                        ),
                         \xoctEventGUI::class,
                         \xoctEventGUI::CMD_EDIT_SCHEDULED,
                         ActionType::INTERNAL_LINK


### PR DESCRIPTION
Fixes #545.

With the plugin setting **"All, except date and recording station"**, the date and recording station of a scheduled event were editable in "Edit Metadata" — they should be read-only, as in release 9.

## Cause

The edit action of a scheduled event only pointed to the scheduled form when the setting was **"All"**. With **"All, except date and recording station"** it fell back to the regular metadata form (`CMD_EDIT`), which renders every configured field — including start date and location — as a plain editable input. The scheduled form's disabling of those fields never applied because that form was not used.

## Fix

Route a scheduled event to the scheduled form (`CMD_EDIT_SCHEDULED`) in every case, matching release 9. That form keeps date and recording station out of the metadata section and disables the scheduling section unless all metadata is editable. The setting now only selects the action label (`event_edit_date` vs `event_edit`).

Behaviour by setting for a scheduled event:

| Setting | Before | After |
| --- | --- | --- |
| No metadata | no edit action | unchanged |
| All | scheduled form, date + station editable | unchanged |
| All, except date and recording station | regular form, everything editable | scheduled form, scheduling section disabled |

Disabled fields are safe on submit: `FormInput::withInput()` does not read disabled inputs from the request but re-applies the transformations to the stored value, so date and recording station are sent back to Opencast unchanged.