### PR TITLE
[FIX] Remove "Report Date Modifications" from per-event actions #544

### DIFF
--- a/src/UI/Integration/Event/EventActionTarget.php
+++ b/src/UI/Integration/Event/EventActionTarget.php
@@ -19,7 +19,6 @@ enum EventActionTarget: string
     case DELETE = 'delete';
     case EDIT_METADATA = 'edit_metadata';
     case REPORT_QUALITY_ISSUE = 'report_quality_issue';
-    case REPORT_DATE_MODIFICATION = 'report_date_modification';
     case GRANT_ACCESS = 'grant_access';
     case EDIT_OWNER = 'edit_owner';
     case REPUBLISH = 'republish';

--- a/src/Views/Event/EventActionResolver.php
+++ b/src/Views/Event/EventActionResolver.php
@@ -300,10 +300,11 @@ class EventActionResolver extends BaseActionResolver implements EventActionTarge
                 );
 
             case EventActionTarget::REPORT_DATE_MODIFICATION:
-                return \ilObjOpenCastAccess::checkAction(
-                    \ilObjOpenCastAccess::ACTION_REPORT_DATE_CHANGE,
-                    $event
-                );
+                // Reporting a date modification concerns the whole series, not a single
+                // event. It is offered through the toolbar button above the list (see
+                // xoctEventGUI::index()), so it must not appear in the per-event actions
+                // as it did in release 9 (see #544).
+                return false;
 
             case EventActionTarget::PLAY:
                 return $this->isEventAccessible($event, $settings);

--- a/src/Views/Event/EventActionResolver.php
+++ b/src/Views/Event/EventActionResolver.php
@@ -171,13 +171,6 @@ class EventActionResolver extends BaseActionResolver implements EventActionTarge
                     \xoctEventGUI::CMD_REPORT_QUALITY_MODAL,
                     ActionType::ASYNC_MODAL
                 );
-            case EventActionTarget::REPORT_DATE_MODIFICATION:
-                return $this->build(
-                    $this->translator->translate('event_report_date_modification'),
-                    \xoctEventGUI::class,
-                    \xoctEventGUI::CMD_REPORT_DATE_MODAL,
-                    ActionType::ASYNC_MODAL
-                );
             case EventActionTarget::START_WORKFLOW:
                 return $this->build(
                     $this->translator->translate('event_startworkflow'),
@@ -298,13 +291,6 @@ class EventActionResolver extends BaseActionResolver implements EventActionTarge
                     \ilObjOpenCastAccess::ACTION_REPORT_QUALITY_PROBLEM,
                     $event
                 );
-
-            case EventActionTarget::REPORT_DATE_MODIFICATION:
-                // Reporting a date modification concerns the whole series, not a single
-                // event. It is offered through the toolbar button above the list (see
-                // xoctEventGUI::index()), so it must not appear in the per-event actions
-                // as it did in release 9 (see #544).
-                return false;
 
             case EventActionTarget::PLAY:
                 return $this->isEventAccessible($event, $settings);


### PR DESCRIPTION
Fixes #544.

"Report Date Modifications" concerns the whole series, not a single event. Release 9 offered it only as a toolbar button above the event list; release 10 additionally showed it in every event's action dropdown.

## Fix

`EventActionResolver::supports()` now returns `false` for `REPORT_DATE_MODIFICATION`, so the action no longer appears per event. The series-wide toolbar button in `xoctEventGUI::index()` is a separate path and is unaffected.