### PR TITLE
[FIX] Show "Converting" status after a plain browser reload #540

### DIFF
--- a/classes/Event/class.xoctEventGUI.php
+++ b/classes/Event/class.xoctEventGUI.php
@@ -710,6 +710,12 @@ class xoctEventGUI extends xoctGUI
 
         $this->addCurrentUserToGroup();
 
+        // Cutting and processing happens later in the external editor, so ILIAS never
+        // sees the state change itself. Drop the cached (still SUCCEEDED) event now, so
+        // a plain browser reload after "Save and process changes" re-fetches the event
+        // and shows the "Converting" status instead of the stale cached one (see #540).
+        $this->event_repository->invalidateCache($event->getIdentifier());
+
         // redirect
         $cutting_link = $event->publications()->getCuttingLink();
 
@@ -1078,6 +1084,9 @@ class xoctEventGUI extends xoctGUI
                 true,
                 true
             );
+            // The workflow moves the event into processing on Opencast; drop the cached
+            // SUCCEEDED state so the reload shows the "Converting" status (see #540).
+            $this->event_repository->invalidateCache($event_id);
             $this->main_tpl->setOnScreenMessage('success', $this->txt('msg_republish_started'), true);
             $this->ctrl->redirect($this, self::CMD_STANDARD);
         } else {
@@ -1137,6 +1146,9 @@ class xoctEventGUI extends xoctGUI
         )) {
             try {
                 $this->unpublish($event);
+                // The unpublish workflow moves the event into processing on Opencast;
+                // drop the cached SUCCEEDED state so the reload reflects it (see #540).
+                $this->event_repository->invalidateCache($event->getIdentifier());
                 $this->main_tpl->setOnScreenMessage('success', $this->txt('msg_unpublish_started'), true);
             } catch (xoctException $e) {
                 if ($e->getCode() == 409) {

--- a/src/Model/Event/EventAPIRepository.php
+++ b/src/Model/Event/EventAPIRepository.php
@@ -82,10 +82,16 @@ class EventAPIRepository implements EventRepository, Request
     public function delete(string $identifier): bool
     {
         $this->api->routes()->eventsApi->delete($identifier);
+        $this->cache->delete($identifier);
         foreach (PermissionGrant::where(['event_identifier' => $identifier])->get() as $invitation) {
             $invitation->delete();
         }
         return true;
+    }
+
+    public function invalidateCache(string $identifier): void
+    {
+        $this->cache->delete($identifier);
     }
 
     /**

--- a/src/Model/Event/EventRepository.php
+++ b/src/Model/Event/EventRepository.php
@@ -23,6 +23,13 @@ interface EventRepository
     public function delete(string $identifier): bool;
 
     /**
+     * Drop the cached state of a single event so the next read re-fetches it from
+     * Opencast. Needed after an action moves the event into processing (cut,
+     * unpublish) where Opencast, not ILIAS, changes the state.
+     */
+    public function invalidateCache(string $identifier): void;
+
+    /**
      * @throws xoctException
      */
     public function upload(UploadEventRequest $request): void;


### PR DESCRIPTION
Fixes #540.

After cutting and re-publishing an already published event, the "Converting, not yet visible to students" status only appeared after clicking "Reload Events", not after a plain browser reload. The same held for unpublishing, deleting and starting a workflow. Release 9 already reflected the new state on a plain reload.

## Cause

The series list re-reads every row through `EventRepository::find()`, which serves events cached in state `SUCCEEDED`/`OFFLINE` for the cache TTL (5 min). When an event moves into processing, that change happens on Opencast, outside ILIAS, so the stale `SUCCEEDED` entry kept being returned until "Reload Events" flushed the whole cache.

## Fix

Invalidate the single event's cache entry whenever ILIAS triggers a state change:

- **Cut** — before redirecting to the external editor (processing starts later, outside ILIAS).
- **Start workflow / republish** — after the workflow run.
- **Unpublish** — after the unpublish workflow.
- **Delete** — `delete()` now also drops the cache entry.

The next list load re-fetches the affected event and shows the "Converting" status, without flushing the whole cache. This also covers the follow-up noted in the review of #554 (event status not updating after starting a workflow).