### PR TITLE
[FIX] Work instruction: keep line breaks in the Content tab #524

### DIFF
--- a/src/Views/Series/Display.php
+++ b/src/Views/Series/Display.php
@@ -42,7 +42,10 @@ class Display implements ViewElement
                     ->factory()
                     ->messageBox()
                     ->info(
-                        $this->object_settings->getIntroductionText()
+                        // The message box renders its text as raw HTML but the stored work
+                        // instruction keeps its line breaks as newlines, which HTML collapses.
+                        // Convert them to <br> so the breaks show in the Content tab (see #524).
+                        nl2br($this->object_settings->getIntroductionText())
                     );
             }
 


### PR DESCRIPTION
Fixes #524.

Line breaks entered in a series work instruction (Settings tab) were ignored in the Content tab — the text appeared as one block.

## Cause

The work instruction is rendered in the Content tab via a UI message box, which outputs its text as raw HTML. The stored newlines are collapsed by HTML. The legacy renderer applied `nl2br`; the new `Display` did not.

## Fix

Apply `nl2br` to the introduction text so its line breaks render again.