### PR TITLE
[FIX] Status labels: no misleading clickable hover #533

### DIFF
--- a/src/UI/Integration/Events.php
+++ b/src/UI/Integration/Events.php
@@ -384,6 +384,11 @@ class Events implements RecordToEntity
             $status_tag = $status_tag->withOnClick(
                 $tooltip->getShowSignal()
             );
+        } else {
+            // Without a best-action tooltip the label does nothing when clicked. Mark the
+            // action as unavailable so it renders as a static label instead of a button
+            // with a misleading clickable hover effect (see #533).
+            $status_tag = $status_tag->withUnavailableAction();
         }
 
         return $entity->withReactions(


### PR DESCRIPTION
Fixes #533.

Status labels (scheduled event, livestream, offline) showed a hover effect suggesting they are clickable, but clicking did nothing.

## Cause

The status label is always rendered as a tag button pointing to `#`. When no "best action" tooltip is attached it has no behaviour, yet the tag still renders as an interactive button with a clickable hover effect.

## Fix

Mark the tag as unavailable (`withUnavailableAction()`) when there is no best-action tooltip, so it renders as a static, non-interactive label. Labels that do carry a best-action popover stay interactive.