### PR TITLE
[FIX] Event download: honor Publication (Sub-)Usage display names #546

### DIFF
--- a/src/Model/Publication/Config/PublicationUsageGroupRepository.php
+++ b/src/Model/Publication/Config/PublicationUsageGroupRepository.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace srag\Plugins\Opencast\Model\Publication\Config;
 
+use srag\Plugins\Opencast\Util\Locale\LocaleTrait;
+
 /**
  * Class PublicationUsageGroupRepository
  *
@@ -11,6 +13,31 @@ namespace srag\Plugins\Opencast\Model\Publication\Config;
  */
 class PublicationUsageGroupRepository
 {
+    use LocaleTrait;
+
+    /**
+     * Returns the display name of the group, looking for a localised record first.
+     */
+    public function getDisplayName(int $group_id): string
+    {
+        $group = PublicationUsageGroup::find($group_id);
+        $display_name = $group === null ? '' : (string) $group->getDisplayName();
+
+        if ($display_name !== '') {
+            $display_name = $this->getLocaleString(
+                strtolower($display_name),
+                PublicationUsageGroup::DISPLAY_NAME_LANG_MODULE,
+                $display_name
+            );
+        }
+
+        if (trim($display_name) === '') {
+            $display_name = $this->getLocaleString('default', PublicationUsageGroup::DISPLAY_NAME_LANG_MODULE);
+        }
+
+        return trim($display_name);
+    }
+
     /**
      * @param array $sub_ids
      * @return array

--- a/src/UI/Integration/Event/Publications.php
+++ b/src/UI/Integration/Event/Publications.php
@@ -134,6 +134,11 @@ class Publications
 
                 $multi = $download_pub_usage->isAllowMultiple();
                 if ($multi) {
+                    // Group the individual downloads of this (sub-)usage under its
+                    // configured display name as a section title. Without it the entries
+                    // only carried their bare resolution/flavor, so every download looked
+                    // like an unnamed "Download" and the configured name was lost (#546).
+                    $elements[] = $this->ui_factory->divider()->horizontal()->withLabel($display_name);
                     foreach ($download_dtos as $dto) {
                         $elements[] = $this->ui_factory->link()->bulky(
                             $icon,

--- a/src/UI/Integration/Event/Publications.php
+++ b/src/UI/Integration/Event/Publications.php
@@ -25,6 +25,7 @@ use srag\Plugins\Opencast\Container\Container;
 use srag\Plugins\Opencast\Model\Event\EventAPIRepository;
 use srag\Plugins\Opencast\Model\Publication\Config\PublicationUsageRepository;
 use srag\Plugins\Opencast\Model\Publication\Config\PublicationSubUsageRepository;
+use srag\Plugins\Opencast\Model\Publication\Config\PublicationUsageGroupRepository;
 use ILIAS\Data\URI;
 use srag\Plugins\Opencast\Model\Publication\Config\PublicationUsage;
 use srag\Plugins\Opencast\UI\MakeURI;
@@ -41,6 +42,7 @@ class Publications
     private Renderer $ui_renderer;
     private PublicationUsageRepository $publication_repository;
     private PublicationSubUsageRepository $publication_sub_repository;
+    private PublicationUsageGroupRepository $publication_group_repository;
 
     public function __construct(
         private UIFactory $ui_factory,
@@ -52,6 +54,7 @@ class Publications
         $this->ui_renderer = $this->container->ilias()->ui()->renderer();
         $this->publication_repository = new PublicationUsageRepository();
         $this->publication_sub_repository = new PublicationSubUsageRepository();
+        $this->publication_group_repository = new PublicationUsageGroupRepository();
     }
 
     /**
@@ -106,6 +109,9 @@ class Publications
         $event = $this->event_repository->find($event_id);
         $categorized_download_dtos = $event->publications()->getDownloadDtos(false);
         $elements = [];
+        // Downloads of (sub-)usages that are assigned to a publication usage group are not
+        // rendered where they occur, but collected here and appended below their group name.
+        $grouped_links = [];
 
         foreach ($categorized_download_dtos as $usage_type => $content) {
             foreach ($content as $usage_id => $download_dtos) {
@@ -150,18 +156,42 @@ class Publications
                         $elements[] = $this->ui_factory->divider()->horizontal();
                     }
                 } else {
-                    $usage_type = $download_pub_usage->isSub() ? 'sub' : 'org';
-                    $elements[] = $this->ui_factory->link()->bulky(
+                    $link = $this->ui_factory->link()->bulky(
                         $icon,
                         $display_name,
                         $target
-                            ->withParameter('usage_type', $usage_type)
+                            ->withParameter('usage_type', $download_pub_usage->isSub() ? 'sub' : 'org')
                             ->withParameter('usage_id', $download_pub_usage->getSubId())
                     )->withAdditionalOnLoadCode(
                         $this->getOnCloseAction()
                     );
+
+                    // A usage that allows multiple downloads brings its own section title above,
+                    // so only single-download usages take part in the grouping (#546).
+                    $group_id = $download_pub_usage->getGroupId();
+                    if ($group_id !== null) {
+                        $grouped_links[$group_id][] = $link;
+                        continue;
+                    }
+
+                    $elements[] = $link;
                     $elements[] = $this->ui_factory->divider()->horizontal();
                 }
+            }
+        }
+
+        foreach ($this->sortGroups($grouped_links) as $group_id => $links) {
+            // A group holding a single download is rendered like any other entry, the group
+            // name would only repeat what the entry already says.
+            if (count($links) > 1) {
+                $elements[] = $this->ui_factory->divider()->horizontal()->withLabel(
+                    $this->publication_group_repository->getDisplayName($group_id)
+                );
+            }
+
+            foreach ($links as $link) {
+                $elements[] = $link;
+                $elements[] = $this->ui_factory->divider()->horizontal();
             }
         }
 
@@ -182,5 +212,33 @@ class Publications
             );
 
         return $alignment;
+    }
+
+    /**
+     * Orders the collected groups the same way the configuration lists them. Groups that no
+     * longer exist keep their downloads, appended in the order they were found.
+     *
+     * @param array<int, array> $grouped_links
+     * @return array<int, array>
+     */
+    private function sortGroups(array $grouped_links): array
+    {
+        if ($grouped_links === []) {
+            return [];
+        }
+
+        $sorted = [];
+        foreach (array_keys(PublicationUsageGroupRepository::getSortedArrayList(array_keys($grouped_links))) as $group_id) {
+            if (isset($grouped_links[$group_id])) {
+                $sorted[(int) $group_id] = $grouped_links[$group_id];
+                unset($grouped_links[$group_id]);
+            }
+        }
+
+        foreach ($grouped_links as $group_id => $links) {
+            $sorted[(int) $group_id] = $links;
+        }
+
+        return $sorted;
     }
 }


### PR DESCRIPTION
Fixes #546.

In the event download menu, every option appeared under a single unnamed "Download" — the configured display names of the Publication Usage / Sub-Usage were ignored. A subtitle sub-usage showed as "Download 4/5" instead of its configured name (e.g. "Untertitel").

## Cause

In `Publications::asList()`, a usage that allows multiple downloads rendered each publication by its bare resolution/flavor only (`$dto->getResolution()`), dropping the configured display name. Only the single-download branch used the display name. With several usages and sub-usages every entry looked like an unnamed "Download".

## Fix

Render the configured (sub-)usage display name as a section title (a labeled divider) above its grouped downloads. Each usage and sub-usage is named as configured again, and the individual quality options are listed underneath — as in release 9. This also addresses the request to show sub-usage group display names as section titles.