### PR TITLE
[Release 10]: Fix for Paella 8 Livestream + Chat (Disappearing Playbar)

### DIFF
--- a/classes/Player/class.xoctPlayerGUI.php
+++ b/classes/Player/class.xoctPlayerGUI.php
@@ -255,7 +255,7 @@ class xoctPlayerGUI extends xoctGUI
         $jwt_module_config->is_live_stream = $event->isLiveEvent();
         if ($jwt_module_config->is_live_stream) {
             $jwt_module_config->hls_source_urls = $jwt_data['urls'] ?? [];
-            $jwt_module_config->hls_check_script = ILIAS_HTTP_PATH . '/' . $this->plugin->getDirectory() . '/src/Util/check_hls_status.php';
+            $jwt_module_config->hls_check_script = ILIAS_HTTP_PATH . '/' . ltrim($this->plugin->getRelativeDirectory(), './') . '/src/Util/check_hls_status.php';
             $jwt_module_config->hls_source_format =
                 PluginConfig::getConfig(PluginConfig::F_LIVESTREAM_TYPE) ?? 'hls';
             $start_utc_atom = $event->getScheduling()

--- a/js/opencast/src/Paella/default_theme/opencast_live_buffered_theme.json
+++ b/js/opencast/src/Paella/default_theme/opencast_live_buffered_theme.json
@@ -1,4 +1,6 @@
 {
+    "name": "ILIAS Opencast LiveStream with buffer theme",
+    "description": "Opencast theme for livestream events with buffer in ILIAS",
     "styleSheets": [
         "opencast_theme.css"
     ],
@@ -8,7 +10,7 @@
         },
         "progressIndicator": {
             "showTotal": false,
-            "parentContainer": "progressIndicator",
+            "parentContainer": "buttonArea",
             "side": "left",
             "visible": true,
             "showHandler": true,
@@ -30,7 +32,8 @@
             },
             "es.upv.paella.playPauseButton": {
                 "enabled": true
-            },"es.upv.paella.customTimeProgressIndicator": {
+            },
+            "es.upv.paella.customTimeProgressIndicator": {
                 "enabled": false
             },
             "es.upv.paella.backwardButtonPlugin": {

--- a/js/opencast/src/Paella/default_theme/opencast_live_theme.json
+++ b/js/opencast/src/Paella/default_theme/opencast_live_theme.json
@@ -1,4 +1,6 @@
 {
+    "name": "ILIAS Opencast LiveStream theme",
+    "description": "Opencast theme for livestream events in ILIAS",
     "styleSheets": [
         "opencast_theme.css"
     ],
@@ -8,7 +10,7 @@
         },
         "progressIndicator": {
             "showTotal": true,
-            "parentContainer": "progressIndicator",
+            "parentContainer": "buttonArea",
             "side": "left",
             "visible": false,
             "showHandler": true,
@@ -30,7 +32,11 @@
             },
             "es.upv.paella.playPauseButton": {
                 "enabled": false
-            },"es.upv.paella.customTimeProgressIndicator": {
+            },
+            "es.upv.paella.customTimeProgressIndicator": {
+                "enabled": false
+            },
+            "es.upv.paella.currentTimeLabel": {
                 "enabled": false
             },
             "es.upv.paella.backwardButtonPlugin": {
@@ -53,6 +59,14 @@
             },
             "es.upv.paella.findCaptionsPlugin": {
                 "enabled": false
+            },
+            "es.upv.paella.liveStreamingProgressIndicator": {
+                "enabled": false
+            },
+            "org.ilias.paella.liveStreamingButtonIndicator": {
+                "enabled": true,
+                "order": 2,
+                "side": "right"
             }
         }
     },

--- a/src/Chat/GUI/ChatGUI.php
+++ b/src/Chat/GUI/ChatGUI.php
@@ -44,7 +44,8 @@ class ChatGUI
         $protocol = ConfigAR::getConfig(ConfigAR::C_PROTOCOL);
         $host = ConfigAR::getConfig(ConfigAR::C_HOST);
 
-        $script_open_chat = ILIAS_HTTP_PATH . '/' . ltrim(__DIR__, ILIAS_ABSOLUTE_PATH) . '/open_chat.php';
+        $relativepath = $this->plugin->getRelativeDirectory();
+        $script_open_chat = ILIAS_HTTP_PATH . '/' . ltrim($relativepath, './') . '/src/Chat/GUI/open_chat.php';
         $url = $script_open_chat .
             '?port=' . $port .
             '&token=' . $this->token->getToken()->toString() .

--- a/src/Chat/node/public/css/chat.css
+++ b/src/Chat/node/public/css/chat.css
@@ -3,12 +3,12 @@ html {
 }
 
 #srchat_iframe_container, #srchat_container {
-    display: inline-block;
     position: relative;
     float: right;
     width: 290px;
     height: 100%;
     overflow: hidden;
+    box-sizing: border-box;
 }
 
 #srchat_history_container {

--- a/src/Model/API/APIObject.php
+++ b/src/Model/API/APIObject.php
@@ -98,7 +98,7 @@ abstract class APIObject implements Request
         $this->setLoaded(true);
     }
 
-    protected function getAsArray(): array
+    public function getAsArray(): array
     {
         $r = new \ReflectionClass($this);
         $array = [];

--- a/src/Util/Player/LivePlayerDataBuilder.php
+++ b/src/Util/Player/LivePlayerDataBuilder.php
@@ -6,6 +6,7 @@ namespace srag\Plugins\Opencast\Util\Player;
 
 use srag\Plugins\Opencast\API\OpencastAPI;
 use srag\Plugins\Opencast\Model\Config\PluginConfig;
+use srag\Plugins\Opencast\Model\User\xoctUser;
 use OpencastApi\Auth\JWT\OcJwtClaim;
 use OpencastApi\Util\OcUtils;
 
@@ -21,15 +22,28 @@ class LivePlayerDataBuilder extends PlayerDataBuilder
      */
     public function buildStreamingData(): array
     {
+        global $DIC;
+        $user = xoctUser::getInstance($DIC->user());
         $jwt_iframe_urls = [];
+        $fallback_tracks = [];
         if ($this->api->isJWTActivated()) {
             // TODO: Major issue in Opencast as it blocks the calls to search endpoints without JWT,
             // however, it returns empty result even with JWT.
             // This issue should be followed from this comment: https://github.com/opencast/opencast/pull/7249#issuecomment-3665403365
             // As a workaround, we fetch the episode data with admin claims to extract the live publication url, which is required for the JWT Iframe player to work. This is not ideal but seems to be the only way until the issue in Opencast is resolved. Once that issue is resolved, we can simply call the search endpoint.
             $oc_claim = new OcJwtClaim();
-            $oc_claim->setUserInfoClaims('admin');
-            $oc_claim->setRoles(['ROLE_ADMIN', 'ROLE_ANONYMOUS']);
+            $oc_claim->setUserInfoClaims(
+                'unknown-jwt-user',
+                'unknown-jwt-user',
+                'no-mail@jwt.invalid'
+            );
+            $user_basic_access_roles = $user->getBasicAccessRoles();
+            $user_role_name = $user->getUserRoleName();
+            $oc_claim->setRoles(array_unique(array_merge($user_basic_access_roles, [$user_role_name, 'ROLE_ADMIN', 'ROLE_ANONYMOUS', 'ROLE_USER_UNKNOWN_JWT_USER', 'ROLE_JWT_USER'])));
+            $event_acl = [
+                $this->event->getIdentifier() => 'read',
+            ];
+            $oc_claim->setEventAcls($event_acl);
             $episode_data = $this->api->routes()->search->withClaims($oc_claim)->getEpisodes(
                 [
                     'id' => $this->event->getIdentifier()
@@ -42,6 +56,21 @@ class LivePlayerDataBuilder extends PlayerDataBuilder
                 $live_publication->getUrl(),
                 $this->event->getIdentifier()
             );
+
+            // A fallback to publication, in case mediapackage fails.
+            $media = $live_publication->getMedia();
+            $fallback_tracks = [];
+            if (empty($episode_data['result']) && !empty($media)) {
+                foreach ($media as $medium) {
+                    $medium_arr = $medium->getAsArray();
+                    $medium_arr['mimetype'] = $medium_arr['mediatype'];
+                    $fallback_tracks[] = $medium_arr;
+                }
+                if (count($fallback_tracks) === 1) {
+                    $fallback_tracks = reset($fallback_tracks);
+                }
+                $episode_data['result']['mediapackage']['media']['track'] = $fallback_tracks;
+            }
         } else {
             $episode_data = $this->api->routes()->search->getEpisodes(
                 [

--- a/templates/default/paella_player.html
+++ b/templates/default/paella_player.html
@@ -17,25 +17,27 @@
 	</style>
 </head>
 <body>
-<div id="playerContainer" class="player-container"></div>
-<div id="overlay_live_waiting" class="overlay_live" hidden>
-	<span class="xoct_pseudo_element"></span>
-	<p id="overlay_live_waiting_text" class="overlay_live_text">{LIVE_WAITING_TEXT}</p>
-</div>
-<div id="overlay_live_interrupted" class="overlay_live" hidden>
-	<span class="xoct_pseudo_element"></span>
-	<p id="overlay_live_interrupted_text" class="overlay_live_text">{LIVE_INTERRUPTED_TEXT}</p>
-</div>
-<div id="overlay_live_over" class="overlay_live" hidden>
-	<span class="xoct_pseudo_element"></span>
-	<p id="overlay_live_over_text" class="overlay_live_text">{LIVE_OVER_TEXT}</p>
-</div>
-<script>
-il.Opencast.Paella.player.init(
-	{DATA},
-	{JS_CONFIG}
-)
-</script>
-{CHAT}
+	<div class="ilias-paella-wrapper">
+		<div id="playerContainer" class="player-container"></div>
+		<div id="overlay_live_waiting" class="overlay_live" hidden>
+			<span class="xoct_pseudo_element"></span>
+			<p id="overlay_live_waiting_text" class="overlay_live_text">{LIVE_WAITING_TEXT}</p>
+		</div>
+		<div id="overlay_live_interrupted" class="overlay_live" hidden>
+			<span class="xoct_pseudo_element"></span>
+			<p id="overlay_live_interrupted_text" class="overlay_live_text">{LIVE_INTERRUPTED_TEXT}</p>
+		</div>
+		<div id="overlay_live_over" class="overlay_live" hidden>
+			<span class="xoct_pseudo_element"></span>
+			<p id="overlay_live_over_text" class="overlay_live_text">{LIVE_OVER_TEXT}</p>
+		</div>
+		{CHAT}
+	</div>
+	<script>
+	il.Opencast.Paella.player.init(
+		{DATA},
+		{JS_CONFIG}
+	)
+	</script>
 </body>
 </html>

--- a/templates/default/player_w_chat.css
+++ b/templates/default/player_w_chat.css
@@ -6,10 +6,15 @@ body {
 	height: 100%;
 }
 
+.ilias-paella-wrapper {
+	height:100dvh;
+	width: 100dvw;
+	overflow: hidden !important;
+}
+
 div#playerContainer, iframe#opencastPaellaJwtPlayer {
 	font-family: roboto;
 	font-weight: 600;
-	display: inline-block !important;
 	position: relative;
 	float: left;
 	width: calc(100% - 290px);


### PR DESCRIPTION
This PR fixes #568.

### Issue

When a livestream with chat enabled is running, the Paella Player does not display the playbar.

### Cause

In Paella Player 8, the player container now uses a CSS grid layout. However, to render the player with the chat panel on the right, we had previously added the following rule:

```css
display: inline-block !important;
```

This override prevented the new PP8 layout from being applied correctly, causing the playbar not to be displayed.

### Main fix

Refactoring the player HTML structure and CSS for the chat-enabled layout. 

### Other changes

While testing with a proper livestream event, I also included a few related improvements:

* Adjusted JWT handling for livestreams.
* Updated the Paella Opencast live theme for better compatibility.