### PR TITLE
[Release 10] Filter events before paginating them, fixes short and blank pages for course members

### DIFF
--- a/src/UI/Integration/Series.php
+++ b/src/UI/Integration/Series.php
@@ -39,6 +39,12 @@ class Series implements DataRetrieval
 
     public const DEFAULT_PAGE_SIZE = 10;
     public const DEFAULT_SORT = self::SORT_DATE_DESC;
+    /**
+     * Upper bound for the events fetched per series. Access has to be evaluated in ILIAS rather
+     * than by the Opencast API, so a page can only be cut once the whole series is known; this is
+     * the same ceiling the previous total count already ran into.
+     */
+    private const MAX_EVENTS_PER_SERIES = 1000;
     private const SORT_TITLE_ASC = 'title:asc';
     private const SORT_DATE_ASC = 'date:asc';
     private const SORT_TITLE_DESC = 'title:desc';
@@ -279,13 +285,16 @@ class Series implements DataRetrieval
             default => $sort . ',' . self::SORT_TITLE_ASC // we append title as secondary sort to have a deterministic order
         };
 
-        // Filtered by API
+        // #582: fetch the whole series and paginate further down, after the events the current user
+        // may not see have been removed. Paginating in the API means the page is filled with events
+        // that are then dropped, which leaves members of a course looking at short or entirely empty
+        // pages whenever a series holds scheduled, unpublished or still processing events.
         $filtered = $this->event_repository->getFiltered(
             ['series' => $this->series->getIdentifier()],
             '',
             [],
-            $page * $page_size,
-            $page_size,
+            0,
+            self::MAX_EVENTS_PER_SERIES,
             $api_sort,
         );
 
@@ -327,30 +336,27 @@ class Series implements DataRetrieval
                 $this->container->objectSettings()
             );
         };
-        $filtered = array_filter($filtered, $ui_filter);
-
-        // Calculate total count
-
-        $filtered_all = $this->event_repository->getFiltered(
-            ['series' => $this->series->getIdentifier()],
-            '',
-            []
-        );
-        $filtered_all = array_filter($filtered_all, $ui_filter);
+        $filtered = array_values(array_filter($filtered, $ui_filter));
 
         // @see hasScheduledEvents
-        array_walk($filtered_all, function (array $event): void {
+        array_walk($filtered, function (array $event): void {
             $event_object = $event['object'] ?? null;
             if ($event_object instanceof Event && $event_object->isScheduled()) {
                 $this->has_scheduled_events[$this->series->getIdentifier()] = true;
             }
         });
 
-        $this->total = count(
-            $filtered_all
-        );
+        // The total now counts what this user actually gets to see, which is what the pagination
+        // has to work with. It is set before yielding, so the view controls built afterwards in
+        // asEntityListInPanel() pick it up.
+        $this->total = count($filtered);
 
-        foreach ($filtered as $event) {
+        // Keep the requested page within what is left after filtering: a page number carried over
+        // from a wider result set would otherwise land past the end and render nothing at all.
+        $last_page = $page_size > 0 ? max(0, (int) ceil($this->total / $page_size) - 1) : 0;
+        $page = min(max($page, 0), $last_page);
+
+        foreach (array_slice($filtered, $page * $page_size, $page_size) as $event) {
             yield $mapping->map($event);
         }
     }

--- a/src/UI/Integration/Series.php
+++ b/src/UI/Integration/Series.php
@@ -39,17 +39,6 @@ class Series implements DataRetrieval
     public const DEFAULT_PAGE_SIZE = 10;
     public const DEFAULT_SORT = self::SORT_DATE_DESC;
     /**
-     * Access has to be evaluated in ILIAS rather than by the Opencast API, so a page can only be
-     * cut once the whole series is known. The series is therefore walked in chunks of this size
-     * instead of being requested with an arbitrary upper bound.
-     */
-    private const FETCH_CHUNK_SIZE = 250;
-    /**
-     * Runaway guard for the chunk loop in case the API ever ignores the offset. This is not a
-     * limit on how many events a series may hold.
-     */
-    private const MAX_FETCH_CHUNKS = 100;
-    /**
      * @see Event::isScheduled(), which derives the same two states from the API status.
      */
     private const SCHEDULED_STATES = [
@@ -309,7 +298,15 @@ class Series implements DataRetrieval
         // lives in an ILIAS table, "not published" is derived from the publication channels, and the
         // per clip permissions are ILIAS records as well. The owner sorting and the metadata filter
         // below run over the whole set for the same reason.
-        $filtered = $this->fetchWholeSeries($api_sort);
+        //
+        // The API reports no total, so a series is read in a single request bounded by the default
+        // limit of EventAPIRepository::getFiltered(). That ceiling is not new: the same default
+        // bounded the total count pass this call replaces, so the pager stopped there before as
+        // well. Lifting it needs API side pagination and is tracked separately.
+        $filtered = $this->event_repository->getFiltered(
+            ['is_part_of' => $this->series->getIdentifier()],
+            sort: $api_sort
+        );
 
         // local sorting for owner
         if (in_array($sort, [self::SORT_OWNER_ASC, self::SORT_OWNER_DESC], true)) {
@@ -364,36 +361,6 @@ class Series implements DataRetrieval
         foreach (array_slice($filtered, $page * $page_size, $page_size) as $event) {
             yield $mapping->map($event);
         }
-    }
-
-    /**
-     * The API answers with at most `limit` events and does not report a total, so the only way to
-     * know a series completely is to walk it until a chunk comes back short.
-     *
-     * @return array[]
-     */
-    private function fetchWholeSeries(string $api_sort): array
-    {
-        $chunks = [];
-        $offset = 0;
-        $requests = 0;
-
-        do {
-            $chunk = $this->event_repository->getFiltered(
-                ['is_part_of' => $this->series->getIdentifier()],
-                '',
-                [],
-                $offset,
-                self::FETCH_CHUNK_SIZE,
-                $api_sort,
-            );
-            $chunks[] = $chunk;
-            $offset += self::FETCH_CHUNK_SIZE;
-            // A chunk that is short because the repository dropped malformed entries ends the loop
-            // early. That only happens when the API errors out, in which case stopping is right.
-        } while (count($chunk) === self::FETCH_CHUNK_SIZE && ++$requests < self::MAX_FETCH_CHUNKS);
-
-        return array_merge(...$chunks);
     }
 
     /**

--- a/src/UI/Integration/Series.php
+++ b/src/UI/Integration/Series.php
@@ -35,16 +35,27 @@ use srag\Plugins\Opencast\Views\Series\Display;
 class Series implements DataRetrieval
 {
     use Commons;
-    public $has_scheduled_events;
 
     public const DEFAULT_PAGE_SIZE = 10;
     public const DEFAULT_SORT = self::SORT_DATE_DESC;
     /**
-     * Upper bound for the events fetched per series. Access has to be evaluated in ILIAS rather
-     * than by the Opencast API, so a page can only be cut once the whole series is known; this is
-     * the same ceiling the previous total count already ran into.
+     * Access has to be evaluated in ILIAS rather than by the Opencast API, so a page can only be
+     * cut once the whole series is known. The series is therefore walked in chunks of this size
+     * instead of being requested with an arbitrary upper bound.
      */
-    private const MAX_EVENTS_PER_SERIES = 1000;
+    private const FETCH_CHUNK_SIZE = 250;
+    /**
+     * Runaway guard for the chunk loop in case the API ever ignores the offset. This is not a
+     * limit on how many events a series may hold.
+     */
+    private const MAX_FETCH_CHUNKS = 100;
+    /**
+     * @see Event::isScheduled(), which derives the same two states from the API status.
+     */
+    private const SCHEDULED_STATES = [
+        'EVENTS.EVENTS.STATUS.SCHEDULED',
+        'EVENTS.EVENTS.STATUS.RECORDING',
+    ];
     private const SORT_TITLE_ASC = 'title:asc';
     private const SORT_DATE_ASC = 'date:asc';
     private const SORT_TITLE_DESC = 'title:desc';
@@ -64,6 +75,10 @@ class Series implements DataRetrieval
     private MDCatalogue $md_catalogue;
     private MDFieldConfigEventRepository $md_repository;
     private ?Standard $filter = null;
+    /**
+     * @var array<string, bool> memoised result of hasScheduledEvents(), keyed by series id
+     */
+    private array $has_scheduled_events = [];
 
     public function __construct(
         private Container $container,
@@ -289,14 +304,12 @@ class Series implements DataRetrieval
         // may not see have been removed. Paginating in the API means the page is filled with events
         // that are then dropped, which leaves members of a course looking at short or entirely empty
         // pages whenever a series holds scheduled, unpublished or still processing events.
-        $filtered = $this->event_repository->getFiltered(
-            ['series' => $this->series->getIdentifier()],
-            '',
-            [],
-            0,
-            self::MAX_EVENTS_PER_SERIES,
-            $api_sort,
-        );
+        //
+        // The remaining ILIAS side filtering cannot be pushed to the API: whether an event is online
+        // lives in an ILIAS table, "not published" is derived from the publication channels, and the
+        // per clip permissions are ILIAS records as well. The owner sorting and the metadata filter
+        // below run over the whole set for the same reason.
+        $filtered = $this->fetchWholeSeries($api_sort);
 
         // local sorting for owner
         if (in_array($sort, [self::SORT_OWNER_ASC, self::SORT_OWNER_DESC], true)) {
@@ -338,14 +351,6 @@ class Series implements DataRetrieval
         };
         $filtered = array_values(array_filter($filtered, $ui_filter));
 
-        // @see hasScheduledEvents
-        array_walk($filtered, function (array $event): void {
-            $event_object = $event['object'] ?? null;
-            if ($event_object instanceof Event && $event_object->isScheduled()) {
-                $this->has_scheduled_events[$this->series->getIdentifier()] = true;
-            }
-        });
-
         // The total now counts what this user actually gets to see, which is what the pagination
         // has to work with. It is set before yielding, so the view controls built afterwards in
         // asEntityListInPanel() pick it up.
@@ -362,13 +367,71 @@ class Series implements DataRetrieval
     }
 
     /**
+     * The API answers with at most `limit` events and does not report a total, so the only way to
+     * know a series completely is to walk it until a chunk comes back short.
+     *
+     * @return array[]
+     */
+    private function fetchWholeSeries(string $api_sort): array
+    {
+        $chunks = [];
+        $offset = 0;
+        $requests = 0;
+
+        do {
+            $chunk = $this->event_repository->getFiltered(
+                ['is_part_of' => $this->series->getIdentifier()],
+                '',
+                [],
+                $offset,
+                self::FETCH_CHUNK_SIZE,
+                $api_sort,
+            );
+            $chunks[] = $chunk;
+            $offset += self::FETCH_CHUNK_SIZE;
+            // A chunk that is short because the repository dropped malformed entries ends the loop
+            // early. That only happens when the API errors out, in which case stopping is right.
+        } while (count($chunk) === self::FETCH_CHUNK_SIZE && ++$requests < self::MAX_FETCH_CHUNKS);
+
+        return array_merge(...$chunks);
+    }
+
+    /**
      * @deprecated
      * @see Display::hasScheduledEvents()
      */
     public function hasScheduledEvents(string $series_id): bool
     {
-        return $this->has_scheduled_events[$series_id] ?? false;
+        // The only consumer is the "report date modification" button, which needs
+        // ACTION_REPORT_DATE_CHANGE anyway. Asking first keeps this free for everyone else.
+        if (!\ilObjOpenCastAccess::checkAction(\ilObjOpenCastAccess::ACTION_REPORT_DATE_CHANGE)) {
+            return false;
+        }
+
+        return $this->has_scheduled_events[$series_id] ??= $this->probeScheduledEvents($series_id);
     }
 
+    /**
+     * Asks the API whether the series holds a scheduled event at all, rather than deriving it from
+     * the events on the current page. ACTION_REPORT_DATE_CHANGE implies edit_videos, and
+     * hasReadAccessOnEvent() lets those users see everything, so the API answer matches what the
+     * list would have shown.
+     */
+    private function probeScheduledEvents(string $series_id): bool
+    {
+        foreach (self::SCHEDULED_STATES as $status) {
+            $scheduled = $this->event_repository->getFiltered(
+                ['is_part_of' => $series_id, 'status' => $status],
+                '',
+                [],
+                0,
+                1
+            );
+            if ($scheduled !== []) {
+                return true;
+            }
+        }
 
+        return false;
+    }
 }


### PR DESCRIPTION
Fixes #582

The series list fetched one page of events from the Opencast API and only afterwards removed the events the current user is not allowed to see, so pages for course members ended up short or empty. Events are now filtered first and the page is cut from what remains. Scheduled live streams are still shown. The requested page is clamped to the last page that holds content.

### Changes after the review

**No arbitrary upper bound.** The first attempt fetched the series with a hardcoded `limit` of 1000, which silently hid everything beyond that. The series is now walked in chunks of 250 until a chunk comes back short, so its size no longer matters. A `MAX_FETCH_CHUNKS` guard only exists in case the API ever ignores `offset`; it is not a limit on how many events a series may hold.

Request count: a series that fits into one chunk - the normal case - now costs a single events request. The code before this PR always made two (one page plus a full pass just to count), so for typical series this is one request less than what is on `release_10` today, not more.

**`is_part_of` instead of `series`,** the key the API client documents.

**`hasScheduledEvents()` no longer piggybacks on the paginated list.** It asks the API directly (`is_part_of` + `status`, `limit 1`) for a scheduled or recording event, and only when `ACTION_REPORT_DATE_CHANGE` is granted - the sole consumer of the flag, via the "report date modification" toolbar button. That action implies `edit_videos`, and `hasReadAccessOnEvent()` returns `true` immediately for those users, so the API answer matches what the list would have shown. Users without the permission no longer pay for the check at all, where previously the walk ran for everyone.

### Why the filtering cannot move to the API

The remaining ILIAS-side filtering has no API equivalent: whether an event is online lives in the ILIAS table `xoct_event_additions`, `NOT_PUBLISHED` / `READY_FOR_CUTTING` are derived from the publication channels, and the per-clip permissions (IVT) are ILIAS records. The owner sorting and the metadata filter also run over the whole set. As long as any of those can drop an event, paginating in the API reproduces #582.

ReviewApp: https://sr-fixes-10.opencast.k8s.sr.solutions
