### PR TITLE
[Release 10] Use the API's documented is_part_of filter key for the series id

### DIFF
--- a/src/UI/EventTableBuilder.php
+++ b/src/UI/EventTableBuilder.php
@@ -68,7 +68,7 @@ class EventTableBuilder
                 ilObjOpenCastAccess::hasPermission(ilObjOpenCastAccess::PERMISSION_EDIT_VIDEOS)
             ),
             $this->applyFilter(
-                $this->eventRepository->getFiltered(['series' => $objectSettings->getSeriesIdentifier()]),
+                $this->eventRepository->getFiltered(['is_part_of' => $objectSettings->getSeriesIdentifier()]),
                 $objectSettings
             ),
             $this->dic->language()->getLangKey(),

--- a/src/UI/Integration/MyEvents.php
+++ b/src/UI/Integration/MyEvents.php
@@ -421,6 +421,13 @@ class MyEvents implements DataRetrieval
             $filter = array_filter($filter, static fn($value): bool => $value !== '');
             $filter['status'] = 'EVENTS.EVENTS.STATUS.PROCESSED';
 
+            // The filter input is keyed 'series' because that is what the stored filter state
+            // uses; the API knows a series only as 'is_part_of'.
+            if (isset($filter['series'])) {
+                $filter['is_part_of'] = $filter['series'];
+                unset($filter['series']);
+            }
+
             // The event list "series" column is sorted by the series name.
             // Opencast supports this natively through the `series_name` sort
             // criterion, so we let the API sort the full result set server-side


### PR DESCRIPTION
Follow-up to #585, which replaced the undocumented `series` filter key with `is_part_of` in `Series.php` only. Two call sites were left behind and still send `series` to the API on 10.4.0.

`EventTableBuilder::table()` now passes `['is_part_of' => …]`.

`MyEvents` maps the key right before the API call. The UI input keeps the key `series` on purpose: the stored filter state is keyed by it, so renaming the input would invalidate every user's saved filter. Only the value handed to `getFiltered()` is renamed.

```php
if (isset($filter['series'])) {
    $filter['is_part_of'] = $filter['series'];
    unset($filter['series']);
}
```

The library documents `is_part_of` as the series filter (`OcEventsApi.php:32`), and `getEventsFromSeries()` sets exactly that key internally, so this brings the plugin in line with the documented API.

`xoctEventAPI::filter(array $filter)` is deliberately untouched — it forwards whatever the caller passes, and nothing inside this plugin calls it. If OpencastPageComponent uses that entry point with a `series` key, it would need the same change on its side.

The identical change is part of #505 for `release_9`.
