### PR TITLE
[Release 10] Fit the player preview image into the visible area #565

### DIFF
--- a/templates/default/player.css
+++ b/templates/default/player.css
@@ -48,3 +48,24 @@
 #opencastPaellaJwtPlayer.hidden {
 	display: none !important;
 }
+
+/* PREVIEW IMAGE (#565)
+   paella-core only gives the preview image `width: 100%` and lets its height follow the aspect
+   ratio. In a window that is narrower than the image, the image therefore grows taller than
+   #playerContainer, whose `overflow: hidden` then cuts off the top and the bottom - the user sees
+   the middle of the thumbnail blown up until playback starts. Bind the image to the container and
+   let it fit inside instead.
+
+   paella-core injects its stylesheet at runtime, so it comes after this file in the document and
+   would win any tie. Going through #playerContainer outweighs the core selectors without reaching
+   for !important.
+   Upstream issue: https://github.com/polimediaupv/paella-player/issues/64 */
+#playerContainer .preview-container > .preview-image-container {
+	height: 100%;
+}
+
+#playerContainer .preview-container > .preview-image-container > .preview-image-landscape,
+#playerContainer .preview-container > .preview-image-container > .preview-image-portrait {
+	height: 100%;
+	object-fit: contain;
+}

--- a/templates/default/player_w_chat.css
+++ b/templates/default/player_w_chat.css
@@ -85,3 +85,24 @@ span.xoct_pseudo_element {
 		width: 100%;
 	}
 }
+
+/* PREVIEW IMAGE (#565)
+   paella-core only gives the preview image `width: 100%` and lets its height follow the aspect
+   ratio. In a window that is narrower than the image, the image therefore grows taller than
+   #playerContainer, whose `overflow: hidden` then cuts off the top and the bottom - the user sees
+   the middle of the thumbnail blown up until playback starts. Bind the image to the container and
+   let it fit inside instead.
+
+   paella-core injects its stylesheet at runtime, so it comes after this file in the document and
+   would win any tie. Going through #playerContainer outweighs the core selectors without reaching
+   for !important.
+   Upstream issue: https://github.com/polimediaupv/paella-player/issues/64 */
+#playerContainer .preview-container > .preview-image-container {
+	height: 100%;
+}
+
+#playerContainer .preview-container > .preview-image-container > .preview-image-landscape,
+#playerContainer .preview-container > .preview-image-container > .preview-image-portrait {
+	height: 100%;
+	object-fit: contain;
+}


### PR DESCRIPTION
Fixes #565.

paella-core renders the preview image before playback with `width: 100%` and no height limit (`.preview-container > .preview-image-container > .preview-image-landscape`). In a window narrower than the image aspect ratio the image grows taller than `#playerContainer`, whose `overflow: hidden` cuts off top and bottom. Since `.preview-container` is vertically centred, only the middle of the thumbnail stays visible until playback starts.

Binds the image to its container with `object-fit: contain`, in `player.css` and `player_w_chat.css` (loaded exclusively of each other, depending on chat).

Selectors go through `#playerContainer`: paella-core injects its stylesheet at runtime, so it comes later in the document and would win an equal-specificity tie. No `!important` needed.

Upstream issue: https://github.com/polimediaupv/paella-player/issues/64 (open). The override does not conflict with a later upstream fix.